### PR TITLE
specs failing due to redis set being nil

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -72,7 +72,6 @@ class Rollout
     def user_within_active_percentage?(feature, user)
       percentage = @redis.get(percentage_key(feature))
       return false if percentage.nil?
-
-      user.id % 10 < percentage.to_i / 10
+      user.id % 100 < percentage.to_i
     end
 end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -19,7 +19,7 @@ describe "Rollout" do
     it "is not active for users for which the block evaluates to false" do
       @rollout.should_not be_active(:chat, stub(:id => 1))
     end
-    
+
     it "is not active if a group is found in Redis but not defined in Rollout" do
       @rollout.activate_group(:chat, :fake)
       @rollout.should_not be_active(:chat, stub(:id => 1))
@@ -112,9 +112,30 @@ describe "Rollout" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..120).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 24
+      (1..120).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 39
     end
   end
+
+  describe "activating a feature for a percentage of users" do
+    before do
+      @rollout.activate_percentage(:chat, 20)
+    end
+
+    it "activates the feature for that percentage of the users" do
+      (1..200).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 40
+    end
+  end
+
+  describe "activating a feature for a percentage of users" do
+    before do
+      @rollout.activate_percentage(:chat, 5)
+    end
+
+    it "activates the feature for that percentage of the users" do
+      (1..100).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 5
+    end
+  end
+
 
   describe "deactivating the percentage of users" do
     before do


### PR DESCRIPTION
With this environment:

bourne (1.0)
columnize (0.3.1)
linecache (0.43)
mocha (0.9.8)
rake (0.8.7)
redis (2.0.10)
resque-lock (0.1.1)
rollout (0.2.0)
rspec (1.3.0)
ruby-debug (0.10.3)
ruby-debug-base (0.10.3)
SystemTimer (1.2)
karl:rollout karl$ ruby -v
ruby 1.8.7 (2010-04-19 patchlevel 253) [i686-darwin10.4.0], MBARI 0x6770, Ruby Enterprise Edition 2010.02

Fixed with an redis.exists.
