### PR TITLE
add activate_all

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,11 +65,19 @@ Deactivate all percentages like this:
 
   $rollout.deactivate_percentage(:chat)
 
+== Give it to everyone
+
+Activate everyone at once:
+
+  $rollout.activate_all(:chat)
+
+This just calls +activate_percentage+ for that feature with 100%.
+
 == Feature is broken
 
 Deactivate everybody at once:
 
-  $rollout.deactivate_all
+  $rollout.deactivate_all(:chat)
 
 For some of our less stable features, we are actually measuring the error rate using redis, and deactivating them automatically when it raises above a certain threshold. It's pretty cool. See http://github.com/jamesgolick/degrade for the failure detection code.
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -12,6 +12,10 @@ class Rollout
     @redis.srem(group_key(feature), group)
   end
 
+  def activate_all(feature)
+    self.activate_percentage(feature, 100)
+  end
+
   def deactivate_all(feature)
     @redis.del(group_key(feature))
     @redis.del(user_key(feature))

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -136,6 +136,15 @@ describe "Rollout" do
     end
   end
 
+  describe "activating a feature for all users" do
+    before do
+      @rollout.activate_all(:chat)
+    end
+
+    it "activates the feature for 100% of users" do
+      (1..100).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 100
+    end
+  end
 
   describe "deactivating the percentage of users" do
     before do


### PR DESCRIPTION
add #activate_all, which is the same as activate_percentage(:feature, 100)

We're looking at using rollout to simply turn features on and off across the whole site, so this is just a little helper to accomplish that.
