### PR TITLE
README: #deactivate_all takes an argument

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -69,7 +69,7 @@ Deactivate all percentages like this:
 
 Deactivate everybody at once:
 
-  $rollout.deactivate_all
+  $rollout.deactivate_all(:chat)
 
 For some of our less stable features, we are actually measuring the error rate using redis, and deactivating them automatically when it raises above a certain threshold. It's pretty cool. See http://github.com/jamesgolick/degrade for the failure detection code.
 


### PR DESCRIPTION
`#deactivate_all` takes the feature name as an argument.
