### PR TITLE
Work with IDs that aren't contiguous

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -1,4 +1,5 @@
 require "rollout/legacy"
+require "zlib"
 
 class Rollout
   class Feature
@@ -61,7 +62,7 @@ class Rollout
 
     private
       def user_in_percentage?(user)
-        user.id % 100 < @percentage
+        Zlib.crc32(user.id.to_s) % 100 < @percentage
       end
 
       def user_in_active_users?(user)


### PR DESCRIPTION
Use `Zlib.crc32()` to provide a simple hash that will randomly distribute IDs to make percentages work in all cases.
