### PR TITLE
Removes double occurence of features in feature list.

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -180,7 +180,7 @@ class Rollout
 
     def save(feature)
       @storage.set(key(feature.name), feature.serialize)
-      @storage.set(features_key, (features + [feature.name]).join(","))
+      @storage.set(features_key, (features | [feature.name]).join(","))
     end
 
     def migrate?

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -206,9 +206,17 @@ describe "Rollout" do
     end
   end
 
-  it "keeps a list of features" do
-    @rollout.activate(:chat)
-    @rollout.features.should be_include(:chat)
+  describe "keeps a list of features" do
+    it "saves the feature" do
+      @rollout.activate(:chat)
+      @rollout.features.should be_include(:chat)
+    end
+
+    it "does not contain doubles" do
+      @rollout.activate(:chat)
+      @rollout.activate(:chat)
+      @rollout.features.size.should == 1
+    end
   end
 
   describe "#get" do


### PR DESCRIPTION
Before: 

``` bash
1354616809.381435 "MONITOR"
1354616840.236863 "get" "feature:tim"
1354616840.237077 "set" "feature:tim" "0|3|"
1354616840.237244 "get" "feature:__features__"
1354616840.237371 "set" "feature:__features__" "tim"
1354616842.463322 "get" "feature:tim"
1354616842.463487 "set" "feature:tim" "0|3|"
1354616842.463613 "get" "feature:__features__"
1354616842.463751 "set" "feature:__features__" "tim,tim"
1354616845.391273 "get" "feature:tim"
1354616845.391451 "set" "feature:tim" "0|3|"
1354616845.391611 "get" "feature:__features__"
1354616845.391768 "set" "feature:__features__" "tim,tim,tim"
1354616853.070983 "get" "feature:ayrton"
1354616853.071137 "set" "feature:ayrton" "0|3|"
1354616853.071331 "get" "feature:__features__"
1354616853.071464 "set" "feature:__features__" "tim,tim,tim,ayrton"
1354616854.999026 "get" "feature:ayrton"
1354616854.999182 "set" "feature:ayrton" "0|3|"
1354616854.999416 "get" "feature:__features__"
1354616854.999546 "set" "feature:__features__" "tim,tim,tim,ayrton,ayrton"
```

After:

``` bash
1354616809.381435 "MONITOR"
1354616840.236863 "get" "feature:tim"
1354616840.237077 "set" "feature:tim" "0|3|"
1354616840.237244 "get" "feature:__features__"
1354616840.237371 "set" "feature:__features__" "tim"
1354616842.463322 "get" "feature:tim"
1354616842.463487 "set" "feature:tim" "0|3|"
1354616842.463613 "get" "feature:__features__"
1354616842.463751 "set" "feature:__features__" "tim"
```
