### PR TITLE
Provide a way to use different storage for legacy migration

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -79,7 +79,7 @@ class Rollout
   def initialize(storage, opts = {})
     @storage  = storage
     @groups = {:all => lambda { |user| true }}
-    @legacy = Legacy.new(@storage) if opts[:migrate]
+    @legacy = Legacy.new(opts[:legacy_storage] || @storage) if opts[:migrate]
   end
 
   def activate(feature)


### PR DESCRIPTION
It would be nice to be able to move to a new storage backend when migrating to the new format.

This adds a `:legacy_storage` option to do that.
