### PR TITLE
Removes double occurence of features in feature list when string is used.

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -180,7 +180,7 @@ class Rollout
 
     def save(feature)
       @storage.set(key(feature.name), feature.serialize)
-      @storage.set(features_key, (features | [feature.name]).join(","))
+      @storage.set(features_key, (features | [feature.name.to_sym]).join(","))
     end
 
     def migrate?

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -217,6 +217,12 @@ describe "Rollout" do
       @rollout.activate(:chat)
       @rollout.features.size.should == 1
     end
+
+    it "does not contain doubles when using string" do
+      @rollout.activate(:chat)
+      @rollout.activate("chat")
+      @rollout.features.size.should == 1
+    end
   end
 
   describe "#get" do


### PR DESCRIPTION
before

``` ruby
@rollout.activate(:chat)
@rollout.activate("chat")

@rollout.features #=> [:chat, :chat]
```

after

``` ruby
@rollout.activate(:chat)
@rollout.activate("chat")

@rollout.features #=> [:chat]
```

the first one will get merged anyway when call #activate again

``` ruby
@rollout.activate(:chat)
@rollout.activate("chat")

@rollout.features #=> [:chat, :chat]

@rollout.activate(:chat)
@rollout.features #=> [:chat]
```

```
```
