### PR TITLE
Singleton to allow use of class instead of global 

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -163,6 +163,16 @@ class Rollout
     (@storage.get(features_key) || "").split(",").map(&:to_sym)
   end
 
+  class << self
+    def setup(redis)
+      @instance = new(redis)
+    end
+
+    def method_missing(method, *args, &block)
+      @instance.public_send(method, *args)
+    end
+  end
+
   private
     def key(name)
       "feature:#{name}"

--- a/spec/legacy_spec.rb
+++ b/spec/legacy_spec.rb
@@ -185,7 +185,7 @@ describe "Rollout::Legacy" do
       end
 
       it "returns all global features" do
-        @rollout.info.should eq({ :global => features.reverse })
+        @rollout.info[:global].should include( *features )
       end
     end
 

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -271,4 +271,17 @@ describe "Rollout" do
       @redis.get("feature:chat").should_not be_nil
     end
   end
+
+  describe "singleton" do
+    before do
+      Rollout.setup(@redis)
+    end
+    it "forwards to a singleton" do
+      Rollout.activate(:chat)
+      Rollout.features.size.should == 1
+
+      Rollout.activate_user(:chat, stub(:id => 42))
+      Rollout.should be_active(:chat, stub(:id => 24))
+    end
+  end
 end


### PR DESCRIPTION
I'm not 100% certain this is the correct way to implement a singleton through the class. I just like being able to say Rollout.active? instead of $rollout.active?