### PR TITLE
Fixes the doc of algorithm for activate_percentage

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -73,7 +73,7 @@ If you're rolling out a new feature, you might want to test the waters by slowly
 
 The algorithm for determining which users get let in is this:
 
-  user.id % 10 < percentage / 10
+  CRC32(user.id) % 100 < percentage
 
 So, for 20%, users 0, 1, 10, 11, 20, 21, etc would be allowed in. Those users would remain in as the percentage increases.
 


### PR DESCRIPTION
The code is:

Zlib.crc32(user.id.to_s) % 100 < @percentage

It's significantly different than currently documented (especially in distribution).
