### PR TITLE
Add user ID flexibility

### DIFF
--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -252,21 +252,6 @@ describe "Rollout" do
     end
   end
 
-  describe "#user_id" do
-    describe "where user is an integer" do
-      it "returns itself as a string" do
-        @rollout.user_id(1).should == "1"
-      end
-    end
-
-    describe "where user is some other object" do
-      it "calls user_id_by and returns itself as a string" do
-        user = stub(:id => 1)
-        @rollout.user_id(user).should == "1"
-      end
-    end
-  end
-
   describe "migration mode" do
     before do
       @legacy = Rollout::Legacy.new(@redis)
@@ -303,7 +288,7 @@ describe "Rollout configuration" do
   describe "setting user_id_by" do
     before do
       @redis   = Redis.new
-      @rollout = Rollout.new(@redis, :user_id_by => :email)
+      @rollout = Rollout.new(@redis, :id_user_by => :email)
       @user = stub(:email => "test@test.com")
     end
 


### PR DESCRIPTION
- As per a suggestion of @JustinAiken in #56, allow either a user object or an ID to be passed to `Rollout#activate_user` and `Rollout#deactivate_user`.
- Rollout now accepts a user_id_by setting, which is the name of the method that should be called by user to id itself. This allows you to ID users by email, IP address, or whatever else you may want to ID them by.
- This approach relies on Rollout doing the user ID translation, while Rollout::Feature instance methods either accept an  `user_id` or `user` object and facilitate building and serializing features for Rollout.
