### PR TITLE
add a section about global actions for features

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -87,13 +87,22 @@ Deactivate all percentages like this:
 
 _Note that activating a feature for 100% of users will also make it active "globally". That is when calling Rollout#active? without a user object._
 
-== Feature is broken
+== Global action
 
-Deactivate everybody at once:
+While groups can come in handy, the actual global setter for a feature does not require a group to be passed.
+
+  $rollout.activate(:chat)
+  
+In that case you can check the global availability of a feature using the following :
+
+  $rollout.active?(:chat)
+  
+And if something is wrong you can set a feature off for everybody using :
 
   $rollout.deactivate(:chat)
 
 For many of our features, we keep track of error rates using redis, and deactivate them automatically when a threshold is reached to prevent service failures from cascading. See http://github.com/jamesgolick/degrade for the failure detection code.
+
 
 == Namespacing
 


### PR DESCRIPTION
The Readme so far is a bit confusing about activation of a feature for all users. It mainly explains how to do it using groups yet using ```activate_group(:feature_a, :all)``` does not cause ```active?(:feature_a)``` to be true.

So this patch rewords a bit the "Feature is broken" section by describing the 3 actions (activate, deactivate, check) from the global point of view.

Follow up : is there a way to check that a feature is active for a specific group ?