### PR TITLE
Added Rollout#clear! to remove feature data

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -165,6 +165,15 @@ class Rollout
     (@storage.get(features_key) || "").split(",").map(&:to_sym)
   end
 
+  def clear!
+    features.each do |feature|
+      with_feature(feature) { |f| f.clear }
+      @storage.del(key(feature))
+    end
+
+    @storage.del(features_key)
+  end
+
   private
     def key(name)
       "feature:#{name}"

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -252,6 +252,30 @@ describe "Rollout" do
     end
   end
 
+  describe "#clear" do
+    let(:features) { %w(signup beta alpha gm) }
+
+    before do
+      features.each { |f| @rollout.activate(f) }
+
+      @rollout.clear!
+    end
+
+    it "each feature is cleared" do
+      features.each do |feature|
+        @rollout.get(feature).to_hash.should == {
+          :percentage => 0,
+          :users => [],
+          :groups => []
+        }
+      end
+    end
+
+    it "removes all features" do
+      @rollout.features.should be_empty
+    end
+  end
+
   describe "migration mode" do
     before do
       @legacy = Rollout::Legacy.new(@redis)


### PR DESCRIPTION
It would be nice to have a way to reset the data without going to Redis directly. I didn't see a way to do this in Rollout so I added it.
