### PR TITLE
Toggle features with a boolean

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -95,6 +95,16 @@ class Rollout
     end
   end
 
+  def set(feature, desired_state)
+    with_feature(feature) do |f|
+      if desired_state
+        f.percentage = 100
+      else
+        f.clear
+      end
+    end
+  end
+
   def activate_group(feature, group)
     with_feature(feature) do |f|
       f.add_group(group)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -206,6 +206,26 @@ describe "Rollout" do
     end
   end
 
+  describe "setting a feature on" do
+    before do
+      @rollout.set(:chat, true)
+    end
+
+    it "becomes activated" do
+      @rollout.should be_active(:chat)
+    end
+  end
+
+  describe "setting a feature off" do
+    before do
+      @rollout.set(:chat, false)
+    end
+
+    it "becomes activated" do
+      @rollout.should_not be_active(:chat)
+    end
+  end
+
   describe "keeps a list of features" do
     it "saves the feature" do
       @rollout.activate(:chat)


### PR DESCRIPTION
I had a need to toggle a feature based on a boolean, and rather than write an if statement to send activate or deactivate, it would be nice if the Rollout object had a method that set the state with a boolean.
