### PR TITLE
Add a convenience wrapper to the Rollout class

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -22,20 +22,23 @@ If you'd prefer to continue to use the old layout in redis, <tt>Rollout::Legacy<
 
 == How it works
 
-Initialize a rollout object. I assign it to a global var.
+Configure the Rollout class (in an initializer or such).
 
   require 'redis'
 
-  $redis   = Redis.new
-  $rollout = Rollout.new($redis)
+  Rollout.storage = Redis.new
+  # or
+  Rollout.setup do |rollout|
+    rollout.storage = Redis.new
+  end
 
 Check whether a feature is active for a particular user:
 
-  $rollout.active?(:chat, User.first) # => true/false
+  Rollout.active?(:chat, User.first) # => true/false
 
 Check whether a feature is active globally:
 
-  $rollout.active?(:chat)
+  Rollout.active?(:chat)
 
 You can activate features using a number of different mechanisms.
 
@@ -45,11 +48,11 @@ Rollout ships with one group by default: "all", which does exactly what it sound
 
 You can activate the all group for the chat feature like this:
 
-  $rollout.activate_group(:chat, :all)
+  Rollout.activate_group(:chat, :all)
 
 You might also want to define your own groups. We have one for our caretakers:
 
-  $rollout.define_group(:caretakers) do |user|
+  Rollout.define_group(:caretakers) do |user|
     user.caretaker?
   end
 
@@ -57,23 +60,23 @@ You can activate multiple groups per feature.
 
 Deactivate groups like this:
 
-  $rollout.deactivate_group(:chat, :all)
+  Rollout.deactivate_group(:chat, :all)
 
 == Specific Users
 
 You might want to let a specific user into a beta test or something. If that user isn't part of an existing group, you can let them in specifically:
 
-  $rollout.activate_user(:chat, @user)
+  Rollout.activate_user(:chat, @user)
 
 Deactivate them like this:
 
-  $rollout.deactivate_user(:chat, @user)
+  Rollout.deactivate_user(:chat, @user)
 
 == User Percentages
 
 If you're rolling out a new feature, you might want to test the waters by slowly enabling it for a percentage of your users.
 
-  $rollout.activate_percentage(:chat, 20)
+  Rollout.activate_percentage(:chat, 20)
 
 The algorithm for determining which users get let in is this:
 
@@ -83,13 +86,13 @@ So, for 20%, users 0, 1, 10, 11, 20, 21, etc would be allowed in. Those users wo
 
 Deactivate all percentages like this:
 
-  $rollout.deactivate_percentage(:chat)
+  Rollout.deactivate_percentage(:chat)
 
 _Note that activating a feature for 100% of users will also make it active "globally". That is when calling Rollout#active? without a user object._
 
 In some cases you might want to have a feature activated for a random set of users. It can come specially handy when using Rollout for split tests.
 
-  $rollout = Rollout.new($redis, randomize_percentage: true)
+  Rollout.options = {randomize_percentage: true}
 
 When on `randomize_percentage` will make sure that 50% of users for feature A are selected independently from users for feature B.
 
@@ -97,7 +100,7 @@ When on `randomize_percentage` will make sure that 50% of users for feature A ar
 
 Deactivate everybody at once:
 
-  $rollout.deactivate(:chat)
+  Rollout.deactivate(:chat)
 
 For many of our features, we keep track of error rates using redis, and deactivate them automatically when a threshold is reached to prevent service failures from cascading. See http://github.com/jamesgolick/degrade for the failure detection code.
 
@@ -108,8 +111,8 @@ Rollout separates its keys from other keys in the data store using the "feature"
 If you're using redis, you can namespace keys further to support multiple environments by using the http://github.com/defunkt/redis-namespace gem.
 
   $ns = Redis::Namespace.new(Rails.env, :redis => $redis)
-  $rollout = Rollout.new($ns)
-  $rollout.activate_group(:chat, :all)
+  Rollout.storage = $ns
+  Rollout.activate_group(:chat, :all)
 
 This example would use the "development:feature:chat:groups" key.
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -3,6 +3,39 @@ require "rollout/legacy"
 require "zlib"
 
 class Rollout
+
+  class << self
+    attr_accessor :storage
+
+    def setup
+      yield self
+    end
+
+    def opts
+      @opts || {}
+    end
+
+    def opts=(options)
+      @opts = options
+    end
+
+    def rollout_instance
+      @rollout_instance ||= Rollout.new(@storage, opts)
+    end
+
+    def reset!
+      @rollout_instance = nil
+    end
+
+    def method_missing(meth, *args, &blk)
+      if rollout_instance && rollout_instance.respond_to?(meth)
+        rollout_instance.send meth, *args, &blk
+      else
+        super
+      end
+    end
+  end
+
   class Feature
     attr_accessor :groups, :users, :percentage
     attr_reader :name, :options

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -6,6 +6,25 @@ describe "Rollout" do
     @rollout = Rollout.new(@redis)
   end
 
+  describe "convenience wrapper" do
+    before { Rollout.reset! }
+
+    it "can be set up via methods" do
+      Rollout.storage = @redis
+      Rollout.activate(:test_accessor)
+      Rollout.should be_active(:test_accessor)
+    end
+
+    it "can set options via a block" do
+      Rollout.setup do |r|
+        r.storage = @redis
+      end
+
+      Rollout.activate(:test_blocked_accessor)
+      Rollout.should be_active(:test_blocked_accessor)
+    end
+  end
+
   describe "when a group is activated" do
     before do
       @rollout.define_group(:fivesonly) { |user| user.id == 5 }


### PR DESCRIPTION
I like my variables with less `$`'s.

This adds a nice convenience wrapper so OTB, there's no need to `$` if you're using a single `Rollout` instance...

I could also tweak if you like:

```ruby
# As-is now, closer to original implementation
Rollout.setup do |rollout|
  rollout.storage = Redis.new
  rollout.options = {migrate: true, randomize_percentage: true, ...}
end

# But I could also make it like this:
Rollout.setup do |rollout|
  rollout.storage              = Redis.new
  rollout.migrate              = true
  rollout.randomize_percentage = true
  ...
end
```

Thoughts?
