### PR TITLE
Update to RSpec 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,24 +8,29 @@ GEM
   specs:
     bourne (1.0)
       mocha (= 0.9.8)
-    diff-lcs (1.1.3)
-    git (1.2.5)
+    diff-lcs (1.2.5)
+    git (1.2.9.1)
     jeweler (1.6.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
     mocha (0.9.8)
       rake
-    rake (0.9.2.2)
-    redis (3.0.7)
-    rspec (2.10.0)
-      rspec-core (~> 2.10.0)
-      rspec-expectations (~> 2.10.0)
-      rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.1)
-    rspec-expectations (2.10.0)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.10.1)
+    rake (10.4.2)
+    redis (3.2.1)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
 
 PLATFORMS
   ruby
@@ -37,4 +42,4 @@ DEPENDENCIES
   mocha (= 0.9.8)
   redis
   rollout!
-  rspec (~> 2.10.0)
+  rspec

--- a/rollout.gemspec
+++ b/rollout.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", "~> 2.10.0"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "jeweler", "~> 1.6.4"
   s.add_development_dependency "bourne", "1.0"

--- a/spec/legacy_spec.rb
+++ b/spec/legacy_spec.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require "spec_helper"
 
-describe "Rollout::Legacy" do
+RSpec.describe "Rollout::Legacy" do
   before do
     @redis   = Redis.new
     @rollout = Rollout::Legacy.new(@redis)
@@ -13,16 +13,16 @@ describe "Rollout::Legacy" do
     end
 
     it "the feature is active for users for which the block evaluates to true" do
-      @rollout.should be_active(:chat, stub(:id => 5))
+      expect(@rollout).to be_active(:chat, double(:id => 5))
     end
 
     it "is not active for users for which the block evaluates to false" do
-      @rollout.should_not be_active(:chat, stub(:id => 1))
+      expect(@rollout).not_to be_active(:chat, double(:id => 1))
     end
 
     it "is not active if a group is found in Redis but not defined in Rollout" do
       @rollout.activate_group(:chat, :fake)
-      @rollout.should_not be_active(:chat, stub(:id => 1))
+      expect(@rollout).not_to be_active(:chat, double(:id => 1))
     end
   end
 
@@ -32,7 +32,7 @@ describe "Rollout::Legacy" do
     end
 
     it "evaluates to true no matter what" do
-      @rollout.should be_active(:chat, stub(:id => 0))
+      expect(@rollout).to be_active(:chat, double(:id => 0))
     end
   end
 
@@ -45,11 +45,11 @@ describe "Rollout::Legacy" do
     end
 
     it "deactivates the rules for that group" do
-      @rollout.should_not be_active(:chat, stub(:id => 10))
+      expect(@rollout).not_to be_active(:chat, double(:id => 10))
     end
 
     it "leaves the other groups active" do
-      @rollout.should be_active(:chat, stub(:id => 5))
+      expect(@rollout).to be_active(:chat, double(:id => 5))
     end
   end
 
@@ -58,56 +58,56 @@ describe "Rollout::Legacy" do
       @rollout.define_group(:fivesonly) { |user| user.id == 5 }
       @rollout.activate_group(:chat, :all)
       @rollout.activate_group(:chat, :fivesonly)
-      @rollout.activate_user(:chat, stub(:id => 51))
+      @rollout.activate_user(:chat, double(:id => 51))
       @rollout.activate_percentage(:chat, 100)
       @rollout.activate_globally(:chat)
       @rollout.deactivate_all(:chat)
     end
 
     it "removes all of the groups" do
-      @rollout.should_not be_active(:chat, stub(:id => 0))
+      expect(@rollout).not_to be_active(:chat, double(:id => 0))
     end
 
     it "removes all of the users" do
-      @rollout.should_not be_active(:chat, stub(:id => 51))
+      expect(@rollout).not_to be_active(:chat, double(:id => 51))
     end
 
     it "removes the percentage" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
 
     it "removes globally" do
-      @rollout.should_not be_active(:chat)
+      expect(@rollout).not_to be_active(:chat)
     end
   end
 
   describe "activating a specific user" do
     before do
-      @rollout.activate_user(:chat, stub(:id => 42))
+      @rollout.activate_user(:chat, double(:id => 42))
     end
 
     it "is active for that user" do
-      @rollout.should be_active(:chat, stub(:id => 42))
+      expect(@rollout).to be_active(:chat, double(:id => 42))
     end
 
     it "remains inactive for other users" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
   end
 
   describe "deactivating a specific user" do
     before do
-      @rollout.activate_user(:chat, stub(:id => 42))
-      @rollout.activate_user(:chat, stub(:id => 24))
-      @rollout.deactivate_user(:chat, stub(:id => 42))
+      @rollout.activate_user(:chat, double(:id => 42))
+      @rollout.activate_user(:chat, double(:id => 24))
+      @rollout.deactivate_user(:chat, double(:id => 42))
     end
 
     it "that user should no longer be active" do
-      @rollout.should_not be_active(:chat, stub(:id => 42))
+      expect(@rollout).not_to be_active(:chat, double(:id => 42))
     end
 
     it "remains active for other active users" do
-      @rollout.should be_active(:chat, stub(:id => 24))
+      expect(@rollout).to be_active(:chat, double(:id => 24))
     end
   end
 
@@ -117,7 +117,7 @@ describe "Rollout::Legacy" do
     end
 
     it "activates the feature" do
-      @rollout.should be_active(:chat)
+      expect(@rollout).to be_active(:chat)
     end
   end
 
@@ -127,7 +127,7 @@ describe "Rollout::Legacy" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..120).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 39
+      expect((1..120).select { |id| @rollout.active?(:chat, double(:id => id)) }.length).to eq(39)
     end
   end
 
@@ -137,7 +137,7 @@ describe "Rollout::Legacy" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..200).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 40
+      expect((1..200).select { |id| @rollout.active?(:chat, double(:id => id)) }.length).to eq(40)
     end
   end
 
@@ -147,7 +147,7 @@ describe "Rollout::Legacy" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..100).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should == 5
+      expect((1..100).select { |id| @rollout.active?(:chat, double(:id => id)) }.length).to eq(5)
     end
   end
 
@@ -159,7 +159,7 @@ describe "Rollout::Legacy" do
     end
 
     it "becomes inactivate for all users" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
   end
 
@@ -170,7 +170,7 @@ describe "Rollout::Legacy" do
     end
 
     it "becomes inactivate" do
-      @rollout.should_not be_active(:chat)
+      expect(@rollout).not_to be_active(:chat)
     end
   end
 
@@ -185,7 +185,7 @@ describe "Rollout::Legacy" do
       end
 
       it "returns all global features" do
-        @rollout.info[:global].should include(*features)
+        expect(@rollout.info[:global]).to include(*features)
       end
     end
 
@@ -195,26 +195,26 @@ describe "Rollout::Legacy" do
         @rollout.activate_group(:chat, :caretakers)
         @rollout.activate_group(:chat, :greeters)
         @rollout.activate_globally(:signup)
-        @rollout.activate_user(:chat, stub(:id => 42))
+        @rollout.activate_user(:chat, double(:id => 42))
       end
 
       it "returns info about all the activations" do
         info = @rollout.info(:chat)
-        info[:percentage].should == 10
-        info[:groups].should include(:caretakers, :greeters)
-        info[:users].should include(42)
-        info[:global].should include(:signup)
+        expect(info[:percentage]).to eq(10)
+        expect(info[:groups]).to include(:caretakers, :greeters)
+        expect(info[:users]).to include(42)
+        expect(info[:global]).to include(:signup)
       end
     end
 
     describe "without a percentage set" do
       it "defaults to 0" do
-        @rollout.info(:chat).should == {
+        expect(@rollout.info(:chat)).to eq({
           :percentage => 0,
           :groups     => [],
           :users      => [],
           :global     => []
-        }
+        })
       end
     end
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require "spec_helper"
 
-describe "Rollout" do
+RSpec.describe "Rollout" do
   before do
     @redis   = Redis.new
     @rollout = Rollout.new(@redis)
@@ -13,16 +13,16 @@ describe "Rollout" do
     end
 
     it "the feature is active for users for which the block evaluates to true" do
-      @rollout.should be_active(:chat, stub(:id => 5))
+      expect(@rollout).to be_active(:chat, double(:id => 5))
     end
 
     it "is not active for users for which the block evaluates to false" do
-      @rollout.should_not be_active(:chat, stub(:id => 1))
+      expect(@rollout).not_to be_active(:chat, double(:id => 1))
     end
 
     it "is not active if a group is found in Redis but not defined in Rollout" do
       @rollout.activate_group(:chat, :fake)
-      @rollout.should_not be_active(:chat, stub(:id => 1))
+      expect(@rollout).not_to be_active(:chat, double(:id => 1))
     end
   end
 
@@ -32,7 +32,7 @@ describe "Rollout" do
     end
 
     it "evaluates to true no matter what" do
-      @rollout.should be_active(:chat, stub(:id => 0))
+      expect(@rollout).to be_active(:chat, double(:id => 0))
     end
   end
 
@@ -47,11 +47,11 @@ describe "Rollout" do
     end
 
     it "deactivates the rules for that group" do
-      @rollout.should_not be_active(:chat, stub(:id => 10))
+      expect(@rollout).not_to be_active(:chat, double(:id => 10))
     end
 
     it "leaves the other groups active" do
-      @rollout.get(:chat).groups.should == [:fivesonly]
+      expect(@rollout.get(:chat).groups).to eq([:fivesonly])
     end
   end
 
@@ -60,40 +60,40 @@ describe "Rollout" do
       @rollout.define_group(:fivesonly) { |user| user.id == 5 }
       @rollout.activate_group(:chat, :all)
       @rollout.activate_group(:chat, :fivesonly)
-      @rollout.activate_user(:chat, stub(:id => 51))
+      @rollout.activate_user(:chat, double(:id => 51))
       @rollout.activate_percentage(:chat, 100)
       @rollout.activate(:chat)
       @rollout.deactivate(:chat)
     end
 
     it "removes all of the groups" do
-      @rollout.should_not be_active(:chat, stub(:id => 0))
+      expect(@rollout).not_to be_active(:chat, double(:id => 0))
     end
 
     it "removes all of the users" do
-      @rollout.should_not be_active(:chat, stub(:id => 51))
+      expect(@rollout).not_to be_active(:chat, double(:id => 51))
     end
 
     it "removes the percentage" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
 
     it "removes globally" do
-      @rollout.should_not be_active(:chat)
+      expect(@rollout).not_to be_active(:chat)
     end
   end
 
   describe "activating a specific user" do
     before do
-      @rollout.activate_user(:chat, stub(:id => 42))
+      @rollout.activate_user(:chat, double(:id => 42))
     end
 
     it "is active for that user" do
-      @rollout.should be_active(:chat, stub(:id => 42))
+      expect(@rollout).to be_active(:chat, double(:id => 42))
     end
 
     it "remains inactive for other users" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
   end
 
@@ -103,43 +103,43 @@ describe "Rollout" do
     end
 
     it "is active for that user" do
-      @rollout.should be_active(:chat, stub(:id => 42))
+      expect(@rollout).to be_active(:chat, double(:id => 42))
     end
 
     it "remains inactive for other users" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
   end
 
   describe "activating a specific user with a string id" do
     before do
-      @rollout.activate_user(:chat, stub(:id => 'user-72'))
+      @rollout.activate_user(:chat, double(:id => 'user-72'))
     end
 
     it "is active for that user" do
-      @rollout.should be_active(:chat, stub(:id => 'user-72'))
+      expect(@rollout).to be_active(:chat, double(:id => 'user-72'))
     end
 
     it "remains inactive for other users" do
-      @rollout.should_not be_active(:chat, stub(:id => 'user-12'))
+      expect(@rollout).not_to be_active(:chat, double(:id => 'user-12'))
     end
   end
 
   describe "deactivating a specific user" do
     before do
-      @rollout.activate_user(:chat, stub(:id => 42))
-      @rollout.activate_user(:chat, stub(:id => 4242))
-      @rollout.activate_user(:chat, stub(:id => 24))
-      @rollout.deactivate_user(:chat, stub(:id => 42))
-      @rollout.deactivate_user(:chat, stub(:id => "4242"))
+      @rollout.activate_user(:chat, double(:id => 42))
+      @rollout.activate_user(:chat, double(:id => 4242))
+      @rollout.activate_user(:chat, double(:id => 24))
+      @rollout.deactivate_user(:chat, double(:id => 42))
+      @rollout.deactivate_user(:chat, double(:id => "4242"))
     end
 
     it "that user should no longer be active" do
-      @rollout.should_not be_active(:chat, stub(:id => 42))
+      expect(@rollout).not_to be_active(:chat, double(:id => 42))
     end
 
     it "remains active for other active users" do
-      @rollout.get(:chat).users.should == %w(24)
+      expect(@rollout.get(:chat).users).to eq(%w(24))
     end
   end
 
@@ -149,7 +149,7 @@ describe "Rollout" do
     end
 
     it "activates the feature" do
-      @rollout.should be_active(:chat)
+      expect(@rollout).to be_active(:chat)
     end
   end
 
@@ -159,7 +159,7 @@ describe "Rollout" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..120).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should be_within(1).of(20)
+      expect((1..120).select { |id| @rollout.active?(:chat, double(:id => id)) }.length).to be_within(1).of(20)
     end
   end
 
@@ -169,7 +169,7 @@ describe "Rollout" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..200).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should be_within(5).of(40)
+      expect((1..200).select { |id| @rollout.active?(:chat, double(:id => id)) }.length).to be_within(5).of(40)
     end
   end
 
@@ -179,7 +179,7 @@ describe "Rollout" do
     end
 
     it "activates the feature for that percentage of the users" do
-      (1..100).select { |id| @rollout.active?(:chat, stub(:id => id)) }.length.should be_within(2).of(5)
+      expect((1..100).select { |id| @rollout.active?(:chat, double(:id => id)) }.length).to be_within(2).of(5)
     end
   end
 
@@ -192,15 +192,15 @@ describe "Rollout" do
 
     it "activates the feature for a random set of users when opt is set" do
       @options[:randomize_percentage] = true
-      chat_users = (1..100).select { |id| @rollout.active?(:chat, stub(:id => id)) }
-      beta_users = (1..100).select { |id| @rollout.active?(:beta, stub(:id => id)) }
-      chat_users.should_not eq beta_users
+      chat_users = (1..100).select { |id| @rollout.active?(:chat, double(:id => id)) }
+      beta_users = (1..100).select { |id| @rollout.active?(:beta, double(:id => id)) }
+      expect(chat_users).not_to eq beta_users
     end
     it "activates the feature for the same set of users when opt is not set" do
       @options[:randomize_percentage] = false
-      chat_users = (1..100).select { |id| @rollout.active?(:chat, stub(:id => id)) }
-      beta_users = (1..100).select { |id| @rollout.active?(:beta, stub(:id => id)) }
-      chat_users.should eq beta_users
+      chat_users = (1..100).select { |id| @rollout.active?(:chat, double(:id => id)) }
+      beta_users = (1..100).select { |id| @rollout.active?(:beta, double(:id => id)) }
+      expect(chat_users).to eq beta_users
     end
   end
 
@@ -211,11 +211,11 @@ describe "Rollout" do
     end
 
     it "the feature is active for users for which the block evaluates to true" do
-      @rollout.should be_active(:chat, stub(:id => 5))
+      expect(@rollout).to be_active(:chat, double(:id => 5))
     end
 
     it "is not active for users for which the block evaluates to false" do
-      @rollout.should_not be_active(:chat, stub(:id => 1))
+      expect(@rollout).not_to be_active(:chat, double(:id => 1))
     end
   end
 
@@ -226,7 +226,7 @@ describe "Rollout" do
     end
 
     it "becomes inactivate for all users" do
-      @rollout.should_not be_active(:chat, stub(:id => 24))
+      expect(@rollout).not_to be_active(:chat, double(:id => 24))
     end
   end
 
@@ -237,7 +237,7 @@ describe "Rollout" do
     end
 
     it "becomes inactivate" do
-      @rollout.should_not be_active(:chat)
+      expect(@rollout).not_to be_active(:chat)
     end
   end
 
@@ -247,7 +247,7 @@ describe "Rollout" do
     end
 
     it "becomes activated" do
-      @rollout.should be_active(:chat)
+      expect(@rollout).to be_active(:chat)
     end
   end
 
@@ -257,26 +257,26 @@ describe "Rollout" do
     end
 
     it "becomes activated" do
-      @rollout.should_not be_active(:chat)
+      expect(@rollout).not_to be_active(:chat)
     end
   end
 
   describe "keeps a list of features" do
     it "saves the feature" do
       @rollout.activate(:chat)
-      @rollout.features.should be_include(:chat)
+      expect(@rollout.features).to be_include(:chat)
     end
 
     it "does not contain doubles" do
       @rollout.activate(:chat)
       @rollout.activate(:chat)
-      @rollout.features.size.should == 1
+      expect(@rollout.features.size).to eq(1)
     end
 
     it "does not contain doubles when using string" do
       @rollout.activate(:chat)
       @rollout.activate("chat")
-      @rollout.features.size.should == 1
+      expect(@rollout.features.size).to eq(1)
     end
   end
 
@@ -286,24 +286,24 @@ describe "Rollout" do
       @rollout.activate_group(:chat, :caretakers)
       @rollout.activate_group(:chat, :greeters)
       @rollout.activate(:signup)
-      @rollout.activate_user(:chat, stub(:id => 42))
+      @rollout.activate_user(:chat, double(:id => 42))
     end
 
     it "returns the feature object" do
       feature = @rollout.get(:chat)
-      feature.groups.should == [:caretakers, :greeters]
-      feature.percentage.should == 10
-      feature.users.should == %w(42)
-      feature.to_hash.should == {
+      expect(feature.groups).to eq([:caretakers, :greeters])
+      expect(feature.percentage).to eq(10)
+      expect(feature.users).to eq(%w(42))
+      expect(feature.to_hash).to eq({
         :groups => [:caretakers, :greeters],
         :percentage => 10,
         :users => %w(42)
-      }
+      })
 
       feature = @rollout.get(:signup)
-      feature.groups.should be_empty
-      feature.users.should be_empty
-      feature.percentage.should == 100
+      expect(feature.groups).to be_empty
+      expect(feature.users).to be_empty
+      expect(feature.percentage).to eq(100)
     end
   end
 
@@ -318,16 +318,16 @@ describe "Rollout" do
 
     it "each feature is cleared" do
       features.each do |feature|
-        @rollout.get(feature).to_hash.should == {
+        expect(@rollout.get(feature).to_hash).to eq({
           :percentage => 0,
           :users => [],
           :groups => []
-        }
+        })
       end
     end
 
     it "removes all features" do
-      @rollout.features.should be_empty
+      expect(@rollout.features).to be_empty
     end
   end
 
@@ -335,44 +335,44 @@ describe "Rollout" do
     before do
       @legacy = Rollout::Legacy.new(@redis)
       @legacy.activate_percentage(:chat, 12)
-      @legacy.activate_user(:chat, stub(:id => 42))
-      @legacy.activate_user(:chat, stub(:id => 24))
+      @legacy.activate_user(:chat, double(:id => 42))
+      @legacy.activate_user(:chat, double(:id => 24))
       @legacy.activate_group(:chat, :dope_people)
       @rollout = Rollout.new(@redis, :migrate => true)
     end
 
     it "imports the settings from the legacy rollout once" do
-      @rollout.get(:chat).to_hash.should == {
+      expect(@rollout.get(:chat).to_hash).to eq({
         :percentage => 12,
         :users => %w(24 42),
         :groups => [:dope_people]
-      }
+      })
       @legacy.deactivate_all(:chat)
-      @rollout.get(:chat).to_hash.should == {
+      expect(@rollout.get(:chat).to_hash).to eq({
         :percentage => 12,
         :users => %w(24 42),
         :groups => [:dope_people]
-      }
-      @redis.get("feature:chat").should_not be_nil
+      })
+      expect(@redis.get("feature:chat")).not_to be_nil
     end
 
     it "imports settings that were globally activated" do
       @legacy.activate_globally(:video_chat)
-      @rollout.get(:video_chat).to_hash[:percentage].should == 100
+      expect(@rollout.get(:video_chat).to_hash[:percentage]).to eq(100)
     end
   end
 end
 
 describe "Rollout::Feature" do
   before do
-    @user    = stub("User", :email => "test@test.com")
+    @user    = double("User", :email => "test@test.com")
     @feature = Rollout::Feature.new(:chat, nil, :id_user_by => :email)
   end
 
   describe "#add_user" do
     it "ids a user using id_user_by" do
       @feature.add_user(@user)
-      @user.should have_received :email
+      expect(@user).to have_received :email
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,5 @@ require 'bourne'
 require 'redis'
 
 RSpec.configure do |config|
-  config.mock_with :mocha
   config.before { Redis.new.flushdb }
 end


### PR DESCRIPTION
This runs `bundle update` and removes the version lock on RSpec, updating to RSpec 3

This also converts the spec syntax to the `expect` syntax, and switches to mocking with RSpec to make use of `double`