### PR TITLE
Add a way to create ids collections on rollout

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -166,7 +166,7 @@ class Rollout
     @groups[group.to_sym] = block
   end
 
-  def define_id_collection(name, ids=[])
+  def define_id_collection(name, ids = [])
     @storage.set("collection:#{name}", ids.join(","))
     @storage.set(collection_key, (collections.keys | [name.to_sym]).join(","))
   end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -55,7 +55,8 @@ class Rollout
         id = user_id(user)
         user_in_percentage?(id) ||
           user_in_active_users?(id) ||
-            user_in_active_group?(user, rollout)
+            user_in_active_group?(user, rollout) ||
+              user_in_collections?(id, rollout)
       end
     end
 
@@ -98,6 +99,12 @@ class Rollout
       def user_in_active_group?(user, rollout)
         @groups.any? do |g|
           rollout.active_in_group?(g, user)
+        end
+      end
+
+      def user_in_collections?(id, rollout)
+        rollout.feature_collections(@name).keys.any? do |collection|
+          rollout.active_in_collection?(collection, id)
         end
       end
   end
@@ -159,6 +166,29 @@ class Rollout
     @groups[group.to_sym] = block
   end
 
+  def define_id_collection(name, ids=[])
+    @storage.set("collection:#{name}", ids.join(","))
+    @storage.set(collection_key, (collections.keys | [name.to_sym]).join(","))
+  end
+
+  def add_collection_to_feature(collection, feature)
+    with_feature(feature) do |feature|
+      @storage.set(collection_feature_key(feature.name), (feature_collections(feature.name).keys | [ collection.to_sym]).join(","))
+    end
+  end
+
+  def collections
+    Hash[*(@storage.get(collection_key) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+  end
+
+  def ids_from_collection(collection)
+    (@storage.get(collection_key(collection)) || "").split(",")
+  end
+
+  def feature_collections(feature)
+    Hash[*(@storage.get(collection_feature_key(feature)) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+  end
+
   def active?(feature, user = nil)
     feature = get(feature)
     feature.active?(self, user)
@@ -179,6 +209,11 @@ class Rollout
   def active_in_group?(group, user)
     f = @groups[group.to_sym]
     f && f.call(user)
+  end
+
+  def active_in_collection?(collection, id)
+    f = collections[collection.to_sym]
+    f && f.split(",").include?(id.to_s)
   end
 
   def get(feature)
@@ -217,6 +252,14 @@ class Rollout
 
     def features_key
       "feature:__features__"
+    end
+
+    def collection_key(collection="__collections__")
+      "collection:#{collection}"
+    end
+
+    def collection_feature_key(feature)
+      "collections_for:#{feature}"
     end
 
     def with_feature(feature)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -178,15 +178,19 @@ class Rollout
   end
 
   def collections
-    Hash[*(@storage.get(collection_key) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+    Hash[*retrieve_from_storage(collection_key).map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+  end
+
+  def retrieve_from_storage(key)
+    (@storage.get(key) || "").split(',')
   end
 
   def ids_from_collection(collection)
-    (@storage.get(collection_key(collection)) || "").split(",")
+    retrieve_from_storage(collection_key(collection))
   end
 
   def feature_collections(feature)
-    Hash[*(@storage.get(collection_feature_key(feature)) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+    Hash[*retrieve_from_storage(collection_feature_key(feature)).map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
   end
 
   def active?(feature, user = nil)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -300,7 +300,7 @@ describe "Rollout" do
     end
 
     it "retrieves all ids from a specific collection" do
-      @rollout.ids_from_collection(:beta_testers).should == ["101", "103"]
+      @rollout.ids_from_collection(:beta_testers).should == %w[101 103]
     end
 
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -280,6 +280,31 @@ describe "Rollout" do
     end
   end
 
+  describe "id collections" do
+    before do
+      @rollout.define_id_collection(:beta_testers, [101, 103])
+    end
+    it "saves the collection" do
+      @rollout.define_id_collection(:my_collection, [101, 102])
+      @rollout.collections.size.should == 2
+    end
+
+    it "is active if the feature is active for a user in a collection" do
+      @rollout.add_collection_to_feature(:beta_testers, :my_feature)
+      @rollout.should be_active(:my_feature, 101)
+    end
+
+    it "is not active if the feature is not active user outside a collection" do
+      @rollout.add_collection_to_feature(:beta_testers, :my_feature)
+      @rollout.should_not be_active(:my_feature, 102)
+    end
+
+    it "retrieves all ids from a specific collection" do
+      @rollout.ids_from_collection(:beta_testers).should == ["101", "103"]
+    end
+
+  end
+
   describe "#get" do
     before do
       @rollout.activate_percentage(:chat, 10)


### PR DESCRIPTION
I have this case: 
- I need to dynamically (using https://github.com/jrallison/rollout_ui) add a "group" and add users to this "group" without need to do a deploy.

In actual way, I can create groups, but group need a deploy to be configured for users ids.

I don't know if it is a valid PR, but I added a way to create "collection" that is a set of ids that will be stored on redis that can dynamically be configured using an UI.

If someone have any question, or this is an invalid PR and do you guys have some idea, just question me :smile: 

Thanks,

:beers: 