### PR TITLE
Add methods to get feature states and active features

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -226,6 +226,18 @@ class Rollout
     (@storage.get(features_key) || "").split(",").map(&:to_sym)
   end
 
+  def feature_states(user = nil)
+    features.each_with_object({}) do |f, hash|
+      hash[f] = active?(f, user)
+    end
+  end
+
+  def active_features(user = nil)
+    features.select do |f|
+      active?(f, user)
+    end
+  end
+
   def clear!
     features.each do |feature|
       with_feature(feature) { |f| f.clear }


### PR DESCRIPTION
We use a rails API and often send feature flags to the client side one by one. With these methods, we can send a summary of the feature flags to the client side.

`Rollout#feature_states` will return a hash where the key is the feature name and the value is a boolean based on if it's active or not. You can optionally pass in the user to get the states for a specific user.

`Rollout#active_features` will return an array of feature names that are active. You can optionally pass in the user to get the active features for that user.

Specs are written for each methods.