### PR TITLE
Fix typo in Rollout#inactive?

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -184,7 +184,7 @@ class Rollout
   end
 
   def inactive?(feature, user = nil)
-    !active(feature, user)
+    !active?(feature, user)
   end
 
   def activate_percentage(feature, percentage)


### PR DESCRIPTION
`Rollout#inactive?` currently calls `Rollout#active` instead of `Rollout#active?`.