### PR TITLE
Expose how user is active

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -59,6 +59,10 @@ class Rollout
       end
     end
 
+    def user_in_active_users?(user)
+      @users.include?(user_id(user))
+    end
+
     def to_hash
       {
         percentage: @percentage,
@@ -90,10 +94,6 @@ class Rollout
         else
           user_id(user)
         end
-      end
-
-      def user_in_active_users?(user)
-        @users.include?(user_id(user))
       end
 
       def user_in_active_group?(user, rollout)
@@ -181,6 +181,11 @@ class Rollout
   def active?(feature, user = nil)
     feature = get(feature)
     feature.active?(self, user)
+  end
+
+  def user_in_active_users?(feature, user = nil)
+    feature = get(feature)
+    feature.user_in_active_users?(user)
   end
 
   def inactive?(feature, user = nil)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -493,6 +493,18 @@ RSpec.describe "Rollout" do
       end
     end
   end
+
+  describe "#user_in_active_users?" do
+    it "returns true if activated for user" do
+      @rollout.activate_user(:chat, double(id: 5))
+      expect(@rollout.user_in_active_users?(:chat, "5")).to eq(true)
+    end
+
+    it "returns false if activated for group" do
+      @rollout.activate_group(:chat, :all)
+      expect(@rollout.user_in_active_users?(:chat, "5")).to eq(false)
+    end
+  end
 end
 
 describe "Rollout::Feature" do


### PR DESCRIPTION
Adds method to determine if user has been explicitly activated, as
opposed to via a percentage or group