### PR TITLE
Allow percentage to be float with three decimal points

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -13,7 +13,7 @@ class Rollout
 
       if string
         raw_percentage,raw_users,raw_groups = string.split("|")
-        @percentage = raw_percentage.to_i
+        @percentage = raw_percentage.to_f
         @users = (raw_users || "").split(",").map(&:to_s).to_set
         @groups = (raw_groups || "").split(",").map(&:to_sym).to_set
       else
@@ -85,7 +85,7 @@ class Rollout
       end
 
       def user_in_percentage?(user)
-        Zlib.crc32(user_id_for_percentage(user)) % 100 < @percentage
+        Zlib.crc32(user_id_for_percentage(user)) % 100_000 < @percentage * 1_000
       end
 
       def user_id_for_percentage(user)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe "Rollout" do
     end
 
     it "activates the feature for that percentage of the users" do
-      expect((1..120).select { |id| @rollout.active?(:chat, double(id: id)) }.length).to be_within(1).of(20)
+      expect((1..100).select { |id| @rollout.active?(:chat, double(id: id)) }.length).to be_within(2).of(20)
     end
   end
 
@@ -237,7 +237,7 @@ RSpec.describe "Rollout" do
     end
 
     it "activates the feature for that percentage of the users" do
-      expect((1..200).select { |id| @rollout.active?(:chat, double(id: id)) }.length).to be_within(5).of(40)
+      expect((1..200).select { |id| @rollout.active?(:chat, double(id: id)) }.length).to be_within(4).of(40)
     end
   end
 
@@ -248,6 +248,16 @@ RSpec.describe "Rollout" do
 
     it "activates the feature for that percentage of the users" do
       expect((1..100).select { |id| @rollout.active?(:chat, double(id: id)) }.length).to be_within(2).of(5)
+    end
+  end
+
+  describe "activating a feature for a percentage of users" do
+    before do
+      @rollout.activate_percentage(:chat, 0.1)
+    end
+
+    it "activates the feature for that percentage of the users" do
+      expect((1..10_000).to_set.select { |id| @rollout.active?(:chat, double(id: id)) }.length).to be_within(2).of(10)
     end
   end
 


### PR DESCRIPTION
* add support for float percentages, eg: `$rollout.activate_percentage(:chat, 0.001)`