### PR TITLE
Add ability to delete feature using string feature name

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -122,8 +122,8 @@ class Rollout
   end
 
   def delete(feature)
-    features = (@storage.get(features_key) || "").split(",").map(&:to_sym)
-    features.delete(feature.to_sym)
+    features = (@storage.get(features_key) || "").split(",")
+    features.delete(feature.to_s)
     @storage.set(features_key, features.join(","))
     @storage.del(key(feature))
   end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -123,7 +123,7 @@ class Rollout
 
   def delete(feature)
     features = (@storage.get(features_key) || "").split(",").map(&:to_sym)
-    features.delete(feature)
+    features.delete(feature.to_sym)
     @storage.set(features_key, features.join(","))
     @storage.del(key(feature))
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -344,6 +344,14 @@ RSpec.describe "Rollout" do
       @rollout.set(:chat, true)
     end
 
+    context "when feature was passed as string" do
+      it "should be removed from features list" do
+        expect(@rollout.features.size).to eq 1
+        @rollout.delete('chat')
+        expect(@rollout.features.size).to eq 0
+      end
+    end
+
     it "should be removed from features list" do
       expect(@rollout.features.size).to eq 1
       @rollout.delete(:chat)


### PR DESCRIPTION
That was confusing that I could add features using string, but couldn't remove them the same way:

```ruby
$rollout.activate_user('chat', user) # works fine
$rollout.delete('chat') # does not work
```