### PR TITLE
Allows miscellaneous data to be saved on individual features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Feature flippers.
 ## MAKE SURE TO READ THIS: 2.X Changes and Migration Path
 
 As of rollout-2.x, only one key is used per feature for performance reasons.
-The serialized format is `percentage|user_id,user_id,...|group,_group...|data_key_1=>data_val_1|data_key_2=>data_val_2|...`. This has
+The serialized format is `percentage|user_id,user_id,...|group,_group...|data_json`. This has
 the effect of making concurrent feature modifications unsafe, but in practice,
 I doubt this will actually be a problem.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Feature flippers.
 ## MAKE SURE TO READ THIS: 2.X Changes and Migration Path
 
 As of rollout-2.x, only one key is used per feature for performance reasons.
-The data format is `percentage|user_id,user_id,...|group,_group...`. This has
+The serialized format is `percentage|user_id,user_id,...|group,_group...|data_key_1=>data_val_1|data_key_2=>data_val_2|...`. This has
 the effect of making concurrent feature modifications unsafe, but in practice,
 I doubt this will actually be a problem.
 
@@ -33,6 +33,12 @@ require 'redis'
 
 $redis   = Redis.new
 $rollout = Rollout.new($redis)
+```
+
+Update data specific to a feature:
+
+```ruby
+@rollout.set_feature_data(:chat, description: 'foo', release_date: 'bar', whatever: 'baz')
 ```
 
 Check whether a feature is active for a particular user:

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -108,7 +108,7 @@ class Rollout
       def serialize_data
         return "" unless @data.is_a? Hash
 
-        @data.to_json.gsub("|", "\\|")
+        @data.to_json
       end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -225,7 +225,7 @@ class Rollout
 
   def set_feature_data(feature, data)
     with_feature(feature) do |f|
-      f.data.merge!(Hash.new(data))
+      f.data.merge!(data) if data.is_a? Hash
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -13,18 +13,18 @@ class Rollout
       @name    = name
 
       if string
-        raw_percentage,raw_users,raw_groups,raw_data = string.split("|")
+        raw_percentage,raw_users,raw_groups,raw_data = string.split(/(?<!\\)\|/)
         @percentage = raw_percentage.to_f
         @users = (raw_users || "").split(",").map(&:to_s).to_set
         @groups = (raw_groups || "").split(",").map(&:to_sym).to_set
-        @data = JSON.parse(raw_data || "{}", symbolize_names: true)
+        @data = raw_data ? JSON.parse(raw_data) : {}
       else
         clear
       end
     end
 
     def serialize
-      "#{@percentage}|#{@users.to_a.join(",")}|#{@groups.to_a.join(",")}|#{@data.to_json}"
+      "#{@percentage}|#{@users.to_a.join(",")}|#{@groups.to_a.join(",")}|#{serialize_data}"
     end
 
     def add_user(user)
@@ -103,6 +103,12 @@ class Rollout
         @groups.any? do |g|
           rollout.active_in_group?(g, user)
         end
+      end
+
+      def serialize_data
+        return "" if @data.to_s.strip.empty?
+
+        @data.to_json.gsub("|", "\\|")
       end
   end
 
@@ -219,7 +225,7 @@ class Rollout
 
   def set_feature_data(feature, data)
     with_feature(feature) do |f|
-      f.data.merge!(data)
+      f.data.merge!(Hash.new(data))
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -13,11 +13,11 @@ class Rollout
       @name    = name
 
       if string
-        raw_percentage,raw_users,raw_groups,raw_data = string.split(/(?<!\\)\|/)
+        raw_percentage,raw_users,raw_groups,raw_data = string.split('|', 4)
         @percentage = raw_percentage.to_f
         @users = (raw_users || "").split(",").map(&:to_s).to_set
         @groups = (raw_groups || "").split(",").map(&:to_sym).to_set
-        @data = raw_data ? JSON.parse(raw_data) : {}
+        @data = raw_data.nil? || raw_data.strip.empty? ? {} : JSON.parse(raw_data)
       else
         clear
       end
@@ -106,7 +106,7 @@ class Rollout
       end
 
       def serialize_data
-        return "" if @data.to_s.strip.empty?
+        return "" unless @data.is_a? Hash
 
         @data.to_json.gsub("|", "\\|")
       end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -554,6 +554,12 @@ RSpec.describe "Rollout" do
       expect(@rollout.get(:chat).data).to include('description' => 'foo', 'release_date' => 'bar')
     end
 
+    it 'does not modify @data if param is empty string' do
+      expect(@rollout.get(:chat).data).to include('description' => 'foo', 'release_date' => 'bar')
+      @rollout.set_feature_data(:chat, "   ")
+      expect(@rollout.get(:chat).data).to include('description' => 'foo', 'release_date' => 'bar')
+    end
+
     it 'properly parses data when it contains a |' do
       user = double("User", id: 8)
       @rollout.activate_user(:chat, user)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -614,6 +614,11 @@ describe "Rollout::Feature" do
           feature = Rollout::Feature.new(:chat, "0||")
           expect(feature.data).to eq({})
         end
+
+        it 'sets @data to empty hash' do
+          feature = Rollout::Feature.new(:chat, "|||   ")
+          expect(feature.data).to eq({})
+        end
       end
     end
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -523,6 +523,36 @@ RSpec.describe "Rollout" do
       expect(@rollout.user_in_active_users?(:chat, "5")).to eq(false)
     end
   end
+
+  describe "#set_feature_data" do
+    before do
+      @rollout.set_feature_data(:chat, description: 'foo', release_date: 'bar')
+    end
+
+    it 'sets the data attribute on feature' do
+      expect(@rollout.get(:chat).data).to include(description: 'foo', release_date: 'bar')
+    end
+
+    it 'updates a data attribute' do
+      @rollout.set_feature_data(:chat, description: 'baz')
+      expect(@rollout.get(:chat).data).to include(description: 'baz', release_date: 'bar')
+    end
+
+    it 'only sets data on specified feature' do
+      @rollout.set_feature_data(:talk, image_url: 'kittens.png')
+      expect(@rollout.get(:chat).data).not_to include(image_url: 'kittens.png')
+      expect(@rollout.get(:chat).data).to include(description: 'foo', release_date: 'bar')
+    end
+  end
+
+  describe "#clear_feature_data" do
+    it 'resets data to empty hash' do
+      @rollout.set_feature_data(:chat, description: 'foo')
+      expect(@rollout.get(:chat).data).to include(description: 'foo')
+      @rollout.clear_feature_data(:chat)
+      expect(@rollout.get(:chat).data).to eq({})
+    end
+  end
 end
 
 describe "Rollout::Feature" do


### PR DESCRIPTION
Adds data to serialized feature string as JSON
`percentage|user_id,user_id,...|group,_group...|data_json`

This data attribute is specific to each individual feature as opposed to
`options` which are the same for all features.