### PR TITLE
make using sets for users and groups optional

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -15,8 +15,8 @@ class Rollout
       if string
         raw_percentage,raw_users,raw_groups,raw_data = string.split('|', 4)
         @percentage = raw_percentage.to_f
-        @users = (raw_users || "").split(",").map(&:to_s).to_set
-        @groups = (raw_groups || "").split(",").map(&:to_sym).to_set
+        @users = users_from_string(raw_users)
+        @groups = groups_from_string(raw_groups)
         @data = raw_data.nil? || raw_data.strip.empty? ? {} : JSON.parse(raw_data)
       else
         clear
@@ -45,8 +45,8 @@ class Rollout
     end
 
     def clear
-      @groups = Set.new
-      @users = Set.new
+      @groups = groups_from_string("")
+      @users = users_from_string("")
       @percentage = 0
       @data = {}
     end
@@ -109,6 +109,24 @@ class Rollout
         return "" unless @data.is_a? Hash
 
         @data.to_json
+      end
+
+      def users_from_string(raw_users)
+        users = (raw_users || "").split(",").map(&:to_s)
+        if @options[:use_sets]
+          users.to_set
+        else
+          users
+        end
+      end
+
+      def groups_from_string(raw_groups)
+        groups = (raw_groups || "").split(",").map(&:to_sym)
+        if @options[:use_sets]
+          groups.to_set
+        else
+          groups
+        end
       end
   end
 

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe "Rollout" do
     end
 
     it "leaves the other groups active" do
+      expect(@rollout.get(:chat).groups).to eq [:fivesonly]
+    end
+
+    it "leaves the other groups active using sets" do
+      @options = @rollout.instance_variable_get("@options")
+      @options[:use_sets] = true
       expect(@rollout.get(:chat).groups).to eq [:fivesonly].to_set
     end
   end
@@ -169,6 +175,15 @@ RSpec.describe "Rollout" do
     end
 
     it "remains active for other active users" do
+      @options = @rollout.instance_variable_get("@options")
+      @options[:use_sets] = false
+      expect(@rollout.get(:chat).users).to eq %w(24)
+    end
+
+    it "remains active for other active users using sets" do
+      @options = @rollout.instance_variable_get("@options")
+      @options[:use_sets] = true
+
       expect(@rollout.get(:chat).users).to eq %w(24).to_set
     end
   end
@@ -399,6 +414,26 @@ RSpec.describe "Rollout" do
 
     it "returns the feature object" do
       feature = @rollout.get(:chat)
+      expect(feature.groups).to eq [:caretakers, :greeters]
+      expect(feature.percentage).to eq 10
+      expect(feature.users).to eq %w(42)
+      expect(feature.to_hash).to eq(
+        groups: [:caretakers, :greeters],
+        percentage: 10,
+        users: %w(42)
+      )
+
+      feature = @rollout.get(:signup)
+      expect(feature.groups).to be_empty
+      expect(feature.users).to be_empty
+      expect(feature.percentage).to eq(100)
+    end
+
+    it "returns the feature objects using sets" do
+      @options = @rollout.instance_variable_get("@options")
+      @options[:use_sets] = true
+
+      feature = @rollout.get(:chat)
       expect(feature.groups).to eq [:caretakers, :greeters].to_set
       expect(feature.percentage).to eq 10
       expect(feature.users).to eq %w(42).to_set
@@ -425,6 +460,18 @@ RSpec.describe "Rollout" do
     end
 
     it "each feature is cleared" do
+      features.each do |feature|
+        expect(@rollout.get(feature).to_hash).to eq(
+          percentage: 0,
+          users: [],
+          groups: []
+        )
+      end
+    end
+
+    it "each feature is cleared with sets" do
+      @options = @rollout.instance_variable_get("@options")
+      @options[:use_sets] = true
       features.each do |feature|
         expect(@rollout.get(feature).to_hash).to eq(
           percentage: 0,


### PR DESCRIPTION
PR to address https://github.com/fetlife/rollout/issues/103

This PR makes using sets optional:

`Rollout.new(Redis.new, use_sets: true)` will use the old behavior with sets

`Rollout.new(Redis.new)` will use the "new" behavior with arrays. This would be the new default. If you prefer to use `set` as default, I can open a new PR and make the "new" behavior optional.


```
require 'redis'
rollout_client = Rollout.new(Redis.new)
iterations = 100
rollout_client.activate(:test_feature)
raw_users = []
100_000.times {|num| raw_users << num }

rollout_client_sets = Rollout.new(Redis.new, use_sets: true)
rollout_client_sets.activate_users(:test_feature, raw_users)

Benchmark.bm do |bm|
  bm.report do
    iterations.times do
      rollout_client.active?(:test_feature, '123')
    end
  end
  
  bm.report do
    iterations.times do
      rollout_client_sets.active?(:test_feature, '123')    end
  end

end

### 3.650000   0.200000   3.850000 (  3.897240)
### 13.150000   0.250000  13.400000 ( 13.426378)
```