### PR TITLE
Fix: update variable name in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $rollout = Rollout.new($redis)
 Update data specific to a feature:
 
 ```ruby
-@rollout.set_feature_data(:chat, description: 'foo', release_date: 'bar', whatever: 'baz')
+$rollout.set_feature_data(:chat, description: 'foo', release_date: 'bar', whatever: 'baz')
 ```
 
 Check whether a feature is active for a particular user:


### PR DESCRIPTION
All the other examples use $rollout. I've have changed to use the same variable name like the rest of the examples.