### PR TITLE
Test against Ruby 2.4 + Fix deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 services:
   - redis-server
 rvm:
+  - 2.4.1
   - 2.3.1
   - 2.2
   - 2.1

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -76,7 +76,7 @@ class Rollout
 
     private
       def user_id(user)
-        if user.is_a?(Fixnum) || user.is_a?(String)
+        if user.is_a?(Integer) || user.is_a?(String)
           user.to_s
         else
           user.send(id_user_by).to_s


### PR DESCRIPTION
Adds the following:
- Support for Ruby 2.4.x
- Fix deprecation warnings for Ruby 2.4.x (`Fixnum` is deprecated and unified into `Integer`).

This fix is backwards compatible since `is_a?(Integer)` and `is_a?(Fixnum)` both return true on earlier Ruby versions.
