### PR TITLE
Add note about defining groups during app startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Deactivate groups like this:
 $rollout.deactivate_group(:chat, :all)
 ```
 
+Groups need to be defined every time your app starts. The logic is not persisted
+anywhere.
+
 ## Specific Users
 
 You might want to let a specific user into a beta test or something. If that


### PR DESCRIPTION
It wasn't obvious to us how the groups worked until we read the code.