### PR TITLE
Implementing deactivate user

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -37,17 +37,17 @@ class Rollout
       @users << id
     end
 
-    def add_deactive_user(user)
+    def add_deactivated_user(user)
       remove_user(user)
 
-      id = deactive_user_id(user)
+      id = deactivated_user_id(user)
 
       @users << id
     end
 
     def remove_user(user)
       @users.delete(active_user_id(user))
-      @users.delete(deactive_user_id(user))
+      @users.delete(deactivated_user_id(user))
     end
 
     def add_group(group)
@@ -68,7 +68,7 @@ class Rollout
     def active?(rollout, user)
       if user
         # deactivate takes highest precedent
-        return false if user_in_deactive_users?(user)
+        return false if user_in_deactivated_users?(user)
 
         id = active_user_id(user)
         user_in_percentage?(id) ||
@@ -83,8 +83,8 @@ class Rollout
       @users.include?(active_user_id(user))
     end
 
-    def user_in_deactive_users?(user)
-      @users.include?(deactive_user_id(user))
+    def user_in_deactivated_users?(user)
+      @users.include?(deactivated_user_id(user))
     end
 
     def to_hash
@@ -101,7 +101,7 @@ class Rollout
         user_id(user)
       end
 
-      def deactive_user_id(user)
+      def deactivated_user_id(user)
         'x' + user_id(user)
       end
 
@@ -216,7 +216,7 @@ class Rollout
 
   def deactivate_user(feature, user)
     with_feature(feature) do |f|
-      f.add_deactive_user(user)
+      f.add_deactivated_user(user)
     end
   end
 
@@ -234,7 +234,7 @@ class Rollout
 
   def deactivate_users(feature, users)
     with_feature(feature) do |f|
-      users.each{|user| f.add_deactive_user(user)}
+      users.each{|user| f.add_deactivated_user(user)}
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -96,6 +96,7 @@ class Rollout
     end
 
     private
+
       def active_user_id(user)
         user_id(user)
       end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -67,7 +67,7 @@ class Rollout
 
     def active?(rollout, user)
       if user
-        # deactivate takes highest precedent
+        # deactivate takes highest precedence
         return false if user_in_deactivated_users?(user)
 
         id = active_user_id(user)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -67,6 +67,9 @@ class Rollout
 
     def active?(rollout, user)
       if user
+        # deactivate takes highest precedent
+        return false if user_in_deactive_users?(user)
+
         id = active_user_id(user)
         user_in_percentage?(id) ||
           user_in_active_users?(id) ||
@@ -78,6 +81,10 @@ class Rollout
 
     def user_in_active_users?(user)
       @users.include?(active_user_id(user))
+    end
+
+    def user_in_deactive_users?(user)
+      @users.include?(deactive_user_id(user))
     end
 
     def to_hash

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -71,9 +71,9 @@ class Rollout
         return false if user_in_deactivated_users?(user)
 
         id = active_user_id(user)
-        user_in_percentage?(id) ||
           user_in_active_users?(id) ||
-            user_in_active_group?(user, rollout)
+            user_in_active_group?(user, rollout) ||
+              user_in_percentage?(id)
       else
         @percentage == 100
       end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -29,7 +29,7 @@ class Rollout
       "#{@percentage}|#{@users.to_a.join(",")}|#{@groups.to_a.join(",")}|#{serialize_data}"
     end
 
-    def add_user(user)
+    def add_active_user(user)
       id = active_user_id(user)
       @users << id unless @users.include?(id)
     end
@@ -181,7 +181,7 @@ class Rollout
 
   def activate_user(feature, user)
     with_feature(feature) do |f|
-      f.add_user(user)
+      f.add_active_user(user)
     end
   end
 
@@ -193,7 +193,7 @@ class Rollout
 
   def activate_users(feature, users)
     with_feature(feature) do |f|
-      users.each{|user| f.add_user(user)}
+      users.each{|user| f.add_active_user(user)}
     end
   end
 
@@ -206,7 +206,7 @@ class Rollout
   def set_users(feature, users)
     with_feature(feature) do |f|
       f.users = []
-      users.each{|user| f.add_user(user)}
+      users.each{|user| f.add_active_user(user)}
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -234,7 +234,7 @@ class Rollout
 
   def deactivate_users(feature, users)
     with_feature(feature) do |f|
-      users.each{|user| f.remove_user(user)}
+      users.each{|user| f.add_deactive_user(user)}
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -238,6 +238,12 @@ class Rollout
     end
   end
 
+  def remove_users(feature, users)
+    with_feature(feature) do |f|
+      users.each{|user| f.remove_user(user)}
+    end
+  end
+
   def set_users(feature, users)
     with_feature(feature) do |f|
       f.users = []

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -208,7 +208,7 @@ class Rollout
 
   def deactivate_user(feature, user)
     with_feature(feature) do |f|
-      f.remove_user(user)
+      f.add_deactive_user(user)
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -30,12 +30,24 @@ class Rollout
     end
 
     def add_active_user(user)
+      remove_user(user)
+
       id = active_user_id(user)
-      @users << id unless @users.include?(id)
+
+      @users << id
+    end
+
+    def add_deactive_user(user)
+      remove_user(user)
+
+      id = deactive_user_id(user)
+
+      @users << id
     end
 
     def remove_user(user)
       @users.delete(active_user_id(user))
+      @users.delete(deactive_user_id(user))
     end
 
     def add_group(group)
@@ -78,12 +90,21 @@ class Rollout
 
     private
       def active_user_id(user)
+        user_id(user)
+      end
+
+      def deactive_user_id(user)
+        'x' + user_id(user)
+      end
+
+      def user_id(user)
         if user.is_a?(Integer) || user.is_a?(String)
           user.to_s
         else
           user.send(id_user_by).to_s
         end
       end
+
 
       def id_user_by
         @options[:id_user_by] || :id

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -5,7 +5,7 @@ require "json"
 
 class Rollout
   RAND_BASE = (2**32 - 1) / 100.0
-  
+
   class Feature
     attr_accessor :groups, :users, :percentage, :data
     attr_reader :name, :options
@@ -30,12 +30,12 @@ class Rollout
     end
 
     def add_user(user)
-      id = user_id(user)
+      id = active_user_id(user)
       @users << id unless @users.include?(id)
     end
 
     def remove_user(user)
-      @users.delete(user_id(user))
+      @users.delete(active_user_id(user))
     end
 
     def add_group(group)
@@ -55,7 +55,7 @@ class Rollout
 
     def active?(rollout, user)
       if user
-        id = user_id(user)
+        id = active_user_id(user)
         user_in_percentage?(id) ||
           user_in_active_users?(id) ||
             user_in_active_group?(user, rollout)
@@ -65,7 +65,7 @@ class Rollout
     end
 
     def user_in_active_users?(user)
-      @users.include?(user_id(user))
+      @users.include?(active_user_id(user))
     end
 
     def to_hash
@@ -77,7 +77,7 @@ class Rollout
     end
 
     private
-      def user_id(user)
+      def active_user_id(user)
         if user.is_a?(Integer) || user.is_a?(String)
           user.to_s
         else
@@ -95,9 +95,9 @@ class Rollout
 
       def user_id_for_percentage(user)
         if @options[:randomize_percentage]
-          user_id(user).to_s + @name.to_s
+          active_user_id(user).to_s + @name.to_s
         else
-          user_id(user)
+          active_user_id(user)
         end
       end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -220,6 +220,12 @@ class Rollout
     end
   end
 
+  def remove_user(feature, user)
+    with_feature(feature) do |f|
+      f.remove_user(user)
+    end
+  end
+
   def activate_users(feature, users)
     with_feature(feature) do |f|
       users.each{|user| f.add_active_user(user)}

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "Rollout" do
     end
   end
 
-  describe "deactivating a group of users" do
+  describe "#deactivating a group of users" do
     context "specified by user objects" do
       let(:active_users) { [double(id: 1), double(id: 2)] }
       let(:inactive_users) { [double(id: 3), double(id: 4)] }

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -670,11 +670,11 @@ RSpec.describe "Rollout" do
 end
 
 describe "Rollout::Feature" do
-  describe "#add_user" do
+  describe "#add_active_user" do
     it "ids a user using id_user_by" do
       user    = double("User", email: "test@test.com")
       feature = Rollout::Feature.new(:chat, nil, id_user_by: :email)
-      feature.add_user(user)
+      feature.add_active_user(user)
       expect(user).to have_received :email
     end
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -177,14 +177,14 @@ RSpec.describe "Rollout" do
     it "remains active for other active users" do
       @options = @rollout.instance_variable_get("@options")
       @options[:use_sets] = false
-      expect(@rollout.get(:chat).users).to eq %w(24)
+      expect(@rollout).to be_active(:chat, double(id: 24))
     end
 
     it "remains active for other active users using sets" do
       @options = @rollout.instance_variable_get("@options")
       @options[:use_sets] = true
 
-      expect(@rollout.get(:chat).users).to eq %w(24).to_set
+      expect(@rollout).to be_active(:chat, double(id: 24))
     end
   end
 
@@ -675,7 +675,8 @@ describe "Rollout::Feature" do
       user    = double("User", email: "test@test.com")
       feature = Rollout::Feature.new(:chat, nil, id_user_by: :email)
       feature.add_active_user(user)
-      expect(user).to have_received :email
+
+      expect(feature.users).to eq %w(test@test.com)
     end
   end
 

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -238,6 +238,35 @@ RSpec.describe "Rollout" do
     end
   end
 
+  describe '#removing an user' do
+    let(:user) { double(id: 42) }
+
+    context 'when user is deactivated' do
+      before do
+        @rollout.activate_group(:chat, :all)
+
+        @rollout.deactivate_user(:chat, user)
+
+        @rollout.remove_user(:chat, user)
+      end
+
+      it "that remove the user from deactive users" do
+        expect(@rollout).to be_active(:chat, user)
+      end
+    end
+
+    context 'when user is activated' do
+      before do
+        @rollout.activate_user(:chat, user)
+
+        @rollout.remove_user(:chat, user)
+      end
+
+      it "that remove the user from active users" do
+        expect(@rollout).not_to be_active(:chat, user)
+      end
+    end
+  end
 
   describe 'set a group of users' do
     it 'should replace the users with the given array' do

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "Rollout" do
         @rollout.remove_user(:chat, user)
       end
 
-      it "that remove the user from deactive users" do
+      it "that remove the user from deactivated users" do
         expect(@rollout).to be_active(:chat, user)
       end
     end
@@ -270,13 +270,13 @@ RSpec.describe "Rollout" do
 
   describe '#removing a group of users' do
     let(:active_users) { [double(id: 42), double(id: 4242)]  }
-    let(:deactive_users) { [double(id: 32), double(id: 3232)] }
+    let(:deactivated_users) { [double(id: 32), double(id: 3232)] }
 
     before do
       @rollout.activate_users(:chat, active_users)
-      @rollout.deactivate_users(:chat, deactive_users)
+      @rollout.deactivate_users(:chat, deactivated_users)
 
-      @rollout.remove_users(:chat, active_users + deactive_users)
+      @rollout.remove_users(:chat, active_users + deactivated_users)
     end
 
     it 'removes users from the features' do

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -268,6 +268,24 @@ RSpec.describe "Rollout" do
     end
   end
 
+  describe '#removing a group of users' do
+    let(:active_users) { [double(id: 42), double(id: 4242)]  }
+    let(:deactive_users) { [double(id: 32), double(id: 3232)] }
+
+    before do
+      @rollout.activate_users(:chat, active_users)
+      @rollout.deactivate_users(:chat, deactive_users)
+
+      @rollout.remove_users(:chat, active_users + deactive_users)
+    end
+
+    it 'removes users from the features' do
+      feature = @rollout.get(:chat)
+
+      expect(feature.users).to be_empty
+    end
+  end
+
   describe 'set a group of users' do
     it 'should replace the users with the given array' do
       users = %w(1 2 3 4)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -188,6 +188,18 @@ RSpec.describe "Rollout" do
     end
   end
 
+  describe '#deactivating a specific user in a group' do
+    before do
+      @rollout.activate_group(:chat, :all)
+
+      @rollout.deactivate_user(:chat, double(id: 42))
+    end
+
+    it "that user should no longer be active" do
+      expect(@rollout).not_to be_active(:chat, double(id: 42))
+    end
+  end
+
   describe "deactivating a group of users" do
     context "specified by user objects" do
       let(:active_users) { [double(id: 1), double(id: 2)] }


### PR DESCRIPTION
reference: https://github.com/fetlife/rollout/issues/87

IMO, The rules should be evaluated by specificity. 
1. User specific rule.
2. Group rule.
3. Percentage rule

Example:
```
$rollout.activate_group(:chat, :all)
$rollout.deactivate_user(:chat, user)
$rollout.active?(:chat, user) # false, because user specific rule takes highest precedence
```

```
$rollout.activate_group(:chat, :group_including_user)
$rollout.deactivate_user(:chat, user)
$rollout.activate_group(:chat, :another_group_including_user)
$rollout.active?(:chat, user) # false, because user specific rule takes highest precedence
```

```
$rollout.deactivate_group(:chat, :group_including_user)
$rollout.activate_user(:chat, user)
$rollout.active?(:chat, user) # true, because user specific rule takes highest precedence
```

### Changes:
1. Denote deactivated user id in `feature#users` by appending `x` in user_id.
2. A single user id can only be added (A user cannot be both active and deactivated)
3. Proper implementing the rules above.
4. Add `Rollout#remove_user` so that the user_id/user specific rule can be removed ( for reducing memory usage on redis ).