### PR TITLE
Fixed documentation for percentage algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $rollout.activate_percentage(:chat, 20)
 The algorithm for determining which users get let in is this:
 
 ```ruby
-CRC32(user.id) % 100_000 < percentage * 1_000
+CRC32(user.id) < (2**32 - 1) / 100.0 * percentage
 ```
 
 So, for 20%, users 0, 1, 10, 11, 20, 21, etc would be allowed in. Those users


### PR DESCRIPTION
The given algorithm on documentation doesn't work to determine user shard on percentage

```
require 'redis'
require 'rollout'

rollout = Rollout.new(Redis.new, randomize_percentage: true)

class TestUser < Struct.new(:id)
end

feature_name = :test_feature
percentage = 50

rollout.activate_percentage(feature_name, percentage)

puts "id - rollout - algorithm"
('a'..'z').each do |id|
  user = TestUser.new(id)
  puts [ id, rollout.active?(feature_name, user), Zlib.crc32("#{id}#{feature_name}") % 100_000 < percentage * 1_000 ].join(' - ')
end

```

Will give you:

```
id - rollout - algorithm
a - true  - true
b - false - true
c - true  - false
d - true  - false
e - false - false
f - true  - true
g - false - false
h - false - false
i - true  - false
j - false - true
k - true  - true
l - true  - false
m - false - false
n - true  - false
o - false - true
p - true  - true
q - false - false
r - true - false
s - false - false
t - false - true
u - true  - false
v - false - false
w - true  - true
x - true  - true
y - false - true
z - true  - false
```

Using CRC32(user.id) < (2**32 - 1) / 100.0 * percentage:

```
('a'..'z').each do |id|
  user = TestUser.new(id)
  puts [ id, rollout.active?(feature_name, user), Zlib.crc32("#{id}#{feature_name}") < (2**32 - 1) / 100.0 * percentage ].join(' - ')
end
```

result:

```
a - true  - true
b - false - false
c - true  - true
d - true  - true
e - false - false
f - true  - true
g - false - false
h - false - false
i - true  - true
j - false - false
k - true  - true
l - true  - true
m - false - false
n - true  - true
o - false - false
p - true  - true
q - false - false
r - true  - true
s - false - false
t - false - false
u - true  - true
v - false - false
w - true  - true
x - true  - true
y - false - false
z - true  - true
```