### PR TITLE
use multiget to build feature states and active features

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -273,15 +273,15 @@ class Rollout
   end
 
   def feature_states(user = nil)
-    features.each_with_object({}) do |f, hash|
-      hash[f] = active?(f, user)
+    multi_get(*features).each_with_object({}) do |f, hash|
+      hash[f.name] = f.active?(self, user)
     end
   end
 
   def active_features(user = nil)
-    features.select do |f|
-      active?(f, user)
-    end
+    multi_get(*features).select do |f|
+      f.active?(self, user)
+    end.map(&:name)
   end
 
   def clear!


### PR DESCRIPTION
Currently when we calculate `feature_states` or `active_features` we perform N + 1 queries to Redis

This PR uses the `multi_get` method for these methods so that we only query Redis twice.