### PR TITLE
Fix crash on multi_get when calling with empty features

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -264,6 +264,8 @@ class Rollout
   end
 
   def multi_get(*features)
+    return [] if features.empty?
+
     feature_keys = features.map { |feature| key(feature) }
     @storage.mget(*feature_keys).map.with_index { |string, index| Feature.new(features[index], string, @options) }
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -605,6 +605,12 @@ RSpec.describe "Rollout" do
       expect(features[2].percentage).to eq 100
       expect(features.size).to eq 3
     end
+
+    describe 'when given feature keys is empty' do
+      it 'returns empty array' do
+        expect(@rollout.multi_get(*[])).to match_array([])
+      end
+    end
   end
 
   describe "#set_feature_data" do


### PR DESCRIPTION
In the latest build 2.4.4 we have #143 merged and start using `multi_get` in `feature_states` and `active_features` but it will raise error when it's called with empty features (that's pretty common when we are running rspec on a test database)

```
       Failure/Error: $rollout.feature_states(user)

       Redis::CommandError:
         ERR wrong number of arguments for 'mget' command
       # ./vendor/bundle/ruby/2.4.0/gems/redis-4.1.2/lib/redis/client.rb:126:in `call'
       # ./vendor/bundle/ruby/2.4.0/gems/redis-4.1.2/lib/redis.rb:930:in `block in mget'
       # ./vendor/bundle/ruby/2.4.0/gems/redis-4.1.2/lib/redis.rb:52:in `block in synchronize'
       # ./vendor/bundle/ruby/2.4.0/gems/redis-4.1.2/lib/redis.rb:52:in `synchronize'
       # ./vendor/bundle/ruby/2.4.0/gems/redis-4.1.2/lib/redis.rb:929:in `mget'
       # ./vendor/bundle/ruby/2.4.0/gems/rollout-2.4.4/lib/rollout.rb:268:in `multi_get'
       # ./vendor/bundle/ruby/2.4.0/gems/rollout-2.4.4/lib/rollout.rb:276:in `feature_states'
```