### PR TITLE
Add link to Rollout UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ This example would use the "development:feature:chat:groups" key.
 
 ## Frontend / UI
 
+* [rollout-ui](https://github.com/fetlife/rollout-ui)
 * [Rollout-Dashboard](https://github.com/fiverr/rollout_dashboard/)
 
 ## Implementations in other languages


### PR DESCRIPTION
Add link to new minimalist rollout admin UI for managing your features.

https://github.com/fetlife/rollout-ui

It's very lightweight and you can set it up in seconds by mounting it as rack app into your Rails app.

![screenshot_index](https://user-images.githubusercontent.com/1935686/88091386-42d15b80-cb8f-11ea-8650-ce9da42cc5b1.png)

![screenshot_show](https://user-images.githubusercontent.com/1935686/88091395-449b1f00-cb8f-11ea-9ad0-3e283cc8ae67.png)
