### PR TITLE
Document $rollout.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ deactivate them automatically when a threshold is reached to prevent service
 failures from cascading. See https://github.com/jamesgolick/degrade for the
 failure detection code.
 
+## Check Rollout Feature
+
+You can inspect the state of your feature using:
+
+```ruby
+>> $rollout.get(:chat)
+=> #<Rollout::Feature:0x00007f99fa4ec528 @data={}, @groups=[:caretakers], @name=:chat, @options={}, @percentage=0.05, @users=["1"]>
+```
+
 ## Namespacing
 
 Rollout separates its keys from other keys in the data store using the


### PR DESCRIPTION
I don't currently have Rollout UI available, so I wanted a console-based way of inspecting the current state of a Rollout feature.

I discovered `get` in Rollout UI:

https://github.com/fetlife/rollout-ui/blob/485b635f69bed32a7b08afaaba65ce9b0d42cdf3/lib/rollout/ui/web.rb#L39-L40

This PR documents `get` so others may benefit.