### PR TITLE
Support `redis-rb` 5

### DIFF
--- a/rollout.gemspec
+++ b/rollout.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'redis', '~> 4.0'
+  spec.add_dependency 'redis', '>= 4.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'pry'

--- a/spec/rollout/feature_spec.rb
+++ b/spec/rollout/feature_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "Rollout::Feature" do
-  let(:rollout) { Rollout.new(Redis.current) }
+  let(:rollout) { Rollout.new($redis) }
 
   describe "#add_user" do
     it "ids a user using id_user_by" do

--- a/spec/rollout/logging_spec.rb
+++ b/spec/rollout/logging_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Rollout::Logging' do
-  let(:rollout) { Rollout.new(Redis.current, logging: logging) }
+  let(:rollout) { Rollout.new($redis, logging: logging) }
   let(:logging) { true }
   let(:feature) { :foo }
 

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "Rollout" do
-  let(:rollout) { Rollout.new(Redis.current) }
+  let(:rollout) { Rollout.new($redis) }
 
   describe "when a group is activated" do
     before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,8 @@ require 'bundler/setup'
 require 'redis'
 require 'rollout'
 
-Redis.current = Redis.new(
+Redis.raise_deprecations = true
+$redis = Redis.new(
   host: ENV.fetch('REDIS_HOST', '127.0.0.1'),
   port: ENV.fetch('REDIS_PORT', '6379'),
   db: ENV.fetch('REDIS_DB', '7'),
@@ -23,5 +24,5 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before { Redis.current.flushdb }
+  config.before { $redis.flushdb }
 end


### PR DESCRIPTION
Fixes https://github.com/fetlife/rollout/issues/166.

I also noticed that some cleanup is needed for this gem: updating rubocop, moving to probably GitHub Actions - it contains configs for travis and circleci (which is currently used), but I was unable to see there why the CI on master is failing.