### PR TITLE
Add `observer` dependency to fix warning on Ruby 3.3

### DIFF
--- a/rollout.gemspec
+++ b/rollout.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
+  spec.add_dependency 'observer'
   spec.add_dependency 'redis', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'


### PR DESCRIPTION
Fixes the following warning printed when using rollout on Ruby 3.0.0:

> observer was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add observer to your Gemfile or gemspec.