### PR TITLE
Add support for automated-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec spec 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false 
+      - name: Release to RubyGems
+        run: bundle exec rake release
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec spec 

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ pkg
 *.gem
 gemfiles/*.lock
 .rspec_status
+.bundle/config
+/vendor
 
 ## PROJECT::SPECIFIC

--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ This example would use the "development:feature:chat:groups" key.
 *   Eric Rafaloff - Maintainer - https://github.com/EricR
 
 
+## Releasing
+
+1. Bump version: `rake version:patch` (or `minor`/`major`)
+2. Commit and tag: `git commit -am "Bump version" && git tag v0.7.3`
+3. Push: `git push origin master --tags`
+
+The GitHub Actions workflow will automatically publish to RubyGems when tags are pushed.
+
 ## Copyright
 
 Copyright (c) 2010-InfinityAndBeyond BitLove, Inc. See LICENSE for details.

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,45 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+namespace :version do
+  desc "Bump patch version"
+  task :patch do
+    bump_version(:patch)
+  end
+  
+  desc "Bump minor version"
+  task :minor do
+    bump_version(:minor)
+  end
+  
+  desc "Bump major version"
+  task :major do
+    bump_version(:major)
+  end
+end
+
+def bump_version(type)
+  require 'rollout/version'
+  current_version = Rollout::VERSION
+  major, minor, patch = current_version.split('.').map(&:to_i)
+  
+  new_version = case type
+  when :major
+    "#{major + 1}.0.0"
+  when :minor
+    "#{major}.#{minor + 1}.0"
+  when :patch
+    "#{major}.#{minor}.#{patch + 1}"
+  end
+  
+  puts "Bumping version from #{current_version} to #{new_version}"
+  
+  # Update version file
+  version_file = 'lib/rollout/version.rb'
+  content = File.read(version_file)
+  updated_content = content.gsub(/VERSION\s*=\s*'[^']+'/, "VERSION = '#{new_version}'")
+  File.write(version_file, updated_content)
+  
+  puts "Version bumped to #{new_version}"
+end


### PR DESCRIPTION
The RubyGems and GitHub Releases are sometimes out of sync or manually overlooked.  
This PR adds an automated release workflow that triggers whenever a tag is pushed to `master`.

### What this does
- Automatically creates a GitHub Release
- Publishes the gem to RubyGems without manual steps

### Why
This keeps releases consistent across platforms and removes the risk of missed or delayed deployments.