### PR TITLE
fix: correct @rollot typo to @rollout in deep_clone

### DIFF
--- a/lib/rollout/feature.rb
+++ b/lib/rollout/feature.rb
@@ -77,7 +77,7 @@ class Rollout
       c = self.clone
       c.instance_variable_set('@rollout', nil)
       c = Marshal.load(Marshal.dump(c))
-      c.instance_variable_set('@rollot', @rollout)
+      c.instance_variable_set('@rollout', @rollout)
       c
     end
 


### PR DESCRIPTION
In `Feature#deep_clone`, the method nils out `@rollout` before Marshal serialization (to avoid serializing the Rollout object), then restores it on the clone — but the restore step writes to `@rollot` (typo), not `@rollout`.

This means the cloned Feature ends up with `@rollout = nil` and a dangling `@rollot` instance variable that nothing reads. The fix restores the value to the correct `@rollout` variable.

**Note:** This has been in the codebase for a long time without apparent issues, so either `deep_clone` is rarely called or nothing downstream needs `@rollout` on the returned clone. Please confirm this behavioral change is safe for your usage before merging.