### PR TITLE
Add FeatureState as the persistence boundary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v3
   pull_request:
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ coverage
 rdoc
 pkg
 *.gem
+Gemfile.lock
 gemfiles/*.lock
+test_results
 .rspec_status
 .bundle/config
 /vendor

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ This example would use the "development:feature:chat:groups" key.
 *   Eric Rafaloff - Maintainer - https://github.com/EricR
 
 
+## Testing
+
+The suite flushes Redis database 7 before every example. Use a disposable
+instance, not a shared or production Redis.
+
+```bash
+docker run --rm -p 6379:6379 redis:7-alpine
+bundle exec rspec
+```
+
+Optional connection settings: `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`.
+
 ## Releasing
 
 1. Bump version: `rake version:patch` (or `minor`/`major`)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -2,6 +2,7 @@
 
 require 'rollout/feature'
 require 'rollout/logging'
+require 'rollout/redis_codec'
 require 'rollout/version'
 require 'zlib'
 require 'set'
@@ -137,8 +138,12 @@ class Rollout
   end
 
   def get(feature)
-    string = @storage.get(key(feature))
-    Feature.new(feature, state: string, rollout: self, options: @options)
+    payload = @storage.get(key(feature))
+    Feature.new(
+      state: RedisCodec.decode(feature, payload),
+      rollout: self,
+      options: @options,
+    )
   end
 
   def set_feature_data(feature, data)
@@ -161,8 +166,12 @@ class Rollout
     @storage
       .mget(*feature_keys)
       .map
-      .with_index do |string, index|
-        Feature.new(features[index], state: string, rollout: self, options: @options)
+      .with_index do |payload, index|
+        Feature.new(
+          state: RedisCodec.decode(features[index], payload),
+          rollout: self,
+          options: @options,
+        )
       end
   end
 
@@ -227,7 +236,7 @@ class Rollout
   end
 
   def save(feature)
-    @storage.set(key(feature.name), feature.serialize)
+    @storage.set(key(feature.name), RedisCodec.encode(feature.to_feature_state))
     @storage.set(features_key, (features | [feature.name.to_sym]).join(','))
   end
 end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -143,6 +143,7 @@ class Rollout
       state: RedisCodec.decode(feature, payload),
       rollout: self,
       options: @options,
+      name: feature,
     )
   end
 
@@ -171,6 +172,7 @@ class Rollout
           state: RedisCodec.decode(features[index], payload),
           rollout: self,
           options: @options,
+          name: features[index],
         )
       end
   end

--- a/lib/rollout/feature.rb
+++ b/lib/rollout/feature.rb
@@ -1,28 +1,27 @@
 # frozen_string_literal: true
 
+require 'rollout/feature_state'
+
 class Rollout
   class Feature
     attr_accessor :groups, :users, :percentage, :data
     attr_reader :name, :options
 
-    def initialize(name, rollout:, state: nil, options: {})
-      @name = name
+    def initialize(state:, rollout:, options: {})
       @rollout = rollout
       @options = options
-
-      if state
-        raw_percentage, raw_users, raw_groups, raw_data = state.split('|', 4)
-        @percentage = raw_percentage.to_f
-        @users = users_from_string(raw_users)
-        @groups = groups_from_string(raw_groups)
-        @data = raw_data.nil? || raw_data.strip.empty? ? {} : JSON.parse(raw_data)
-      else
-        clear
-      end
+      @name = state.name
+      assign_state(state)
     end
 
-    def serialize
-      "#{@percentage}|#{@users.to_a.join(',')}|#{@groups.to_a.join(',')}|#{serialize_data}"
+    def to_feature_state
+      FeatureState.new(
+        name: @name,
+        percentage: @percentage,
+        users: Array(@users),
+        groups: Array(@groups),
+        data: @data,
+      )
     end
 
     def add_user(user)
@@ -43,10 +42,15 @@ class Rollout
     end
 
     def clear
-      @groups = groups_from_string('')
-      @users = users_from_string('')
-      @percentage = 0
-      @data = {}
+      assign_state(
+        FeatureState.new(
+          name: @name,
+          percentage: 0,
+          users: [],
+          groups: [],
+          data: {},
+        ),
+      )
     end
 
     def active?(user)
@@ -83,6 +87,16 @@ class Rollout
 
     private
 
+    def assign_state(state)
+      state = state.deep_clone
+
+      @name = state.name
+      @percentage = state.percentage
+      @users = users_from_array(state.users)
+      @groups = groups_from_array(state.groups)
+      @data = state.data
+    end
+
     def user_id(user)
       if user.is_a?(Integer) || user.is_a?(String)
         user.to_s
@@ -113,14 +127,8 @@ class Rollout
       end
     end
 
-    def serialize_data
-      return '' unless @data.is_a? Hash
-
-      @data.to_json
-    end
-
-    def users_from_string(raw_users)
-      users = (raw_users || '').split(',').map(&:to_s)
+    def users_from_array(users)
+      users = Array(users).map(&:to_s)
       if @options[:use_sets]
         users.to_set
       else
@@ -128,8 +136,8 @@ class Rollout
       end
     end
 
-    def groups_from_string(raw_groups)
-      groups = (raw_groups || '').split(',').map(&:to_sym)
+    def groups_from_array(groups)
+      groups = Array(groups).map(&:to_sym)
       if @options[:use_sets]
         groups.to_set
       else

--- a/lib/rollout/feature.rb
+++ b/lib/rollout/feature.rb
@@ -7,9 +7,10 @@ class Rollout
     attr_accessor :groups, :users, :percentage, :data
     attr_reader :name, :options
 
-    def initialize(state:, rollout:, options: {})
+    def initialize(state:, rollout:, options: {}, name: nil)
       @rollout = rollout
       @options = options
+      @name = name.nil? ? state.name.to_sym : name
       assign_state(state)
     end
 
@@ -81,7 +82,6 @@ class Rollout
     def assign_state(state)
       state = state.deep_clone
 
-      @name = state.name.to_sym
       @percentage = state.percentage
       @users = users_from_array(state.users)
       @groups = groups_from_array(state.groups)

--- a/lib/rollout/feature.rb
+++ b/lib/rollout/feature.rb
@@ -10,7 +10,6 @@ class Rollout
     def initialize(state:, rollout:, options: {})
       @rollout = rollout
       @options = options
-      @name = state.name
       assign_state(state)
     end
 
@@ -42,15 +41,7 @@ class Rollout
     end
 
     def clear
-      assign_state(
-        FeatureState.new(
-          name: @name,
-          percentage: 0,
-          users: [],
-          groups: [],
-          data: {},
-        ),
-      )
+      assign_state(FeatureState.new(name: @name, percentage: 0))
     end
 
     def active?(user)
@@ -90,7 +81,7 @@ class Rollout
     def assign_state(state)
       state = state.deep_clone
 
-      @name = state.name
+      @name = state.name.to_sym
       @percentage = state.percentage
       @users = users_from_array(state.users)
       @groups = groups_from_array(state.groups)

--- a/lib/rollout/feature_state.rb
+++ b/lib/rollout/feature_state.rb
@@ -49,8 +49,10 @@ class Rollout
         value.map { |item| dup_value(item) }
       when String
         value.dup
-      else
+      when Integer, Float, TrueClass, FalseClass, NilClass, Symbol
         value
+      else
+        raise ArgumentError, "unsupported data value: #{value.class}"
       end
     end
   end

--- a/lib/rollout/feature_state.rb
+++ b/lib/rollout/feature_state.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Rollout
+  class FeatureState
+    attr_reader :name, :percentage, :users, :groups, :data
+
+    def initialize(name:, percentage:, users: [], groups: [], data: {})
+      @name = name.to_s
+      @percentage = percentage.to_f
+      @users = Array(users).map(&:to_s)
+      @groups = Array(groups).map(&:to_s)
+      @data = stringify_keys(data)
+    end
+
+    def ==(other)
+      other.is_a?(FeatureState) &&
+        name == other.name &&
+        percentage == other.percentage &&
+        users == other.users &&
+        groups == other.groups &&
+        data == other.data
+    end
+
+    def deep_clone
+      self.class.new(
+        name: name,
+        percentage: percentage,
+        users: users,
+        groups: groups,
+        data: data,
+      )
+    end
+
+    private
+
+    def stringify_keys(hash)
+      hash.each_with_object({}) do |(key, value), result|
+        result[key.to_s] = dup_value(value)
+      end
+    end
+
+    def dup_value(value)
+      case value
+      when Hash
+        stringify_keys(value)
+      when Array
+        value.map { |item| dup_value(item) }
+      when String
+        value.dup
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/rollout/feature_state.rb
+++ b/lib/rollout/feature_state.rb
@@ -5,10 +5,12 @@ class Rollout
     attr_reader :name, :percentage, :users, :groups, :data
 
     def initialize(name:, percentage:, users: [], groups: [], data: {})
-      @name = name.to_s
+      raise ArgumentError, "data must be a Hash" unless data.is_a?(Hash)
+
+      @name = name.to_s.dup
       @percentage = percentage.to_f
-      @users = Array(users).map(&:to_s)
-      @groups = Array(groups).map(&:to_s)
+      @users = Array(users).map { |user| user.to_s.dup }
+      @groups = Array(groups).map { |group| group.to_s.dup }
       @data = stringify_keys(data)
     end
 

--- a/lib/rollout/redis_codec.rb
+++ b/lib/rollout/redis_codec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rollout/feature_state'
+
+class Rollout
+  class RedisCodec
+    def self.decode(name, payload)
+      if payload.nil? || payload.empty?
+        return FeatureState.new(
+          name: name,
+          percentage: 0,
+          users: [],
+          groups: [],
+          data: {},
+        )
+      end
+
+      raw_percentage, raw_users, raw_groups, raw_data = payload.split('|', 4)
+      data = raw_data.nil? || raw_data.strip.empty? ? {} : JSON.parse(raw_data)
+
+      FeatureState.new(
+        name: name,
+        percentage: raw_percentage.to_f,
+        users: (raw_users || '').split(','),
+        groups: (raw_groups || '').split(','),
+        data: data,
+      )
+    end
+
+    def self.encode(feature_state)
+      "#{feature_state.percentage}|#{feature_state.users.join(',')}|#{feature_state.groups.join(',')}|#{feature_state.data.to_json}"
+    end
+  end
+end

--- a/spec/rollout/feature_spec.rb
+++ b/spec/rollout/feature_spec.rb
@@ -3,52 +3,36 @@ require "spec_helper"
 describe "Rollout::Feature" do
   let(:rollout) { Rollout.new($redis) }
 
+  def feature_for(state, options: {})
+    Rollout::Feature.new(state: state, rollout: rollout, options: options)
+  end
+
   describe "#add_user" do
     it "ids a user using id_user_by" do
-      user    = double("User", email: "test@test.com")
-      feature = Rollout::Feature.new(:chat, state: nil, rollout: rollout, options: { id_user_by: :email })
+      user = double("User", email: "test@test.com")
+      feature = feature_for(
+        Rollout::RedisCodec.decode(:chat, nil),
+        options: { id_user_by: :email },
+      )
       feature.add_user(user)
       expect(user).to have_received :email
     end
   end
 
   describe "#initialize" do
-    describe "when string does not exist" do
-      it 'clears feature attributes when string is not given' do
-        feature = Rollout::Feature.new(:chat, rollout: rollout)
-        expect(feature.groups).to be_empty
-        expect(feature.users).to be_empty
-        expect(feature.percentage).to eq 0
-        expect(feature.data).to eq({})
-      end
+    it "uses the state's name" do
+      feature = feature_for(Rollout::FeatureState.new(name: :video, percentage: 0))
 
-      it 'clears feature attributes when string is nil' do
-        feature = Rollout::Feature.new(:chat, state: nil, rollout: rollout)
-        expect(feature.groups).to be_empty
-        expect(feature.users).to be_empty
-        expect(feature.percentage).to eq 0
-        expect(feature.data).to eq({})
-      end
+      expect(feature.name).to eq "video"
+    end
 
-      it 'clears feature attributes when string is empty string' do
-        feature = Rollout::Feature.new(:chat, state: "", rollout: rollout)
-        expect(feature.groups).to be_empty
-        expect(feature.users).to be_empty
-        expect(feature.percentage).to eq 0
-        expect(feature.data).to eq({})
-      end
+    it "clears feature attributes for an empty state" do
+      feature = feature_for(Rollout::RedisCodec.decode(:chat, nil))
 
-      describe "when there is no data" do
-        it 'sets @data to empty hash' do
-          feature = Rollout::Feature.new(:chat, state: "0||", rollout: rollout)
-          expect(feature.data).to eq({})
-        end
-
-        it 'sets @data to empty hash' do
-          feature = Rollout::Feature.new(:chat, state: "|||   ", rollout: rollout)
-          expect(feature.data).to eq({})
-        end
-      end
+      expect(feature.groups).to be_empty
+      expect(feature.users).to be_empty
+      expect(feature.percentage).to eq 0
+      expect(feature.data).to eq({})
     end
   end
 end

--- a/spec/rollout/feature_spec.rb
+++ b/spec/rollout/feature_spec.rb
@@ -26,6 +26,19 @@ describe "Rollout::Feature" do
       expect(feature.name).to eq :video
     end
 
+    it "preserves an explicit public name" do
+      feature = Rollout::Feature.new(
+        state: Rollout::FeatureState.new(name: :chat, percentage: 0),
+        rollout: rollout,
+        name: "chat",
+      )
+      feature.percentage = 50
+      feature.clear
+
+      expect(feature.name).to eq "chat"
+      expect(feature.to_feature_state.name).to eq "chat"
+    end
+
     it "clears feature attributes for an empty state" do
       feature = feature_for(Rollout::RedisCodec.decode(:chat, nil))
 

--- a/spec/rollout/feature_spec.rb
+++ b/spec/rollout/feature_spec.rb
@@ -23,7 +23,7 @@ describe "Rollout::Feature" do
     it "uses the state's name" do
       feature = feature_for(Rollout::FeatureState.new(name: :video, percentage: 0))
 
-      expect(feature.name).to eq "video"
+      expect(feature.name).to eq :video
     end
 
     it "clears feature attributes for an empty state" do

--- a/spec/rollout/feature_state_spec.rb
+++ b/spec/rollout/feature_state_spec.rb
@@ -44,6 +44,38 @@ RSpec.describe Rollout::FeatureState do
     expect(state.data).to eq("labels" => ["a"])
   end
 
+  it "accepts nested JSON-compatible metadata" do
+    state = build_state(
+      data: {
+        "description" => "New navigation",
+        "updated_at" => 1,
+        "enabled" => true,
+        "ratio" => 0.5,
+        "owner" => nil,
+        "labels" => ["a", { "nested" => :ok }],
+      },
+    )
+
+    expect(state.data).to eq(
+      "description" => "New navigation",
+      "updated_at" => 1,
+      "enabled" => true,
+      "ratio" => 0.5,
+      "owner" => nil,
+      "labels" => ["a", { "nested" => :ok }],
+    )
+  end
+
+  it "rejects unsupported metadata values" do
+    expect {
+      build_state(data: { "released_at" => Time.utc(2026, 1, 1) })
+    }.to raise_error(ArgumentError, "unsupported data value: Time")
+
+    expect {
+      build_state(data: { "labels" => ["a", Set.new(["b"])] })
+    }.to raise_error(ArgumentError, "unsupported data value: Set")
+  end
+
   it "does not share nested data or strings with its clone" do
     description = +"hello"
     state = build_state(data: { "description" => description, "labels" => ["a"] })
@@ -91,6 +123,15 @@ RSpec.describe Rollout::FeatureState do
 
       expect(feature).not_to respond_to(:assign_state)
       expect(feature.private_methods).to include(:assign_state)
+    end
+
+    it "rejects unsupported metadata when converting a Feature" do
+      feature = feature_for(build_state)
+      feature.data["released_at"] = Time.utc(2026, 1, 1)
+
+      expect {
+        feature.to_feature_state
+      }.to raise_error(ArgumentError, "unsupported data value: Time")
     end
 
     it "does not share nested data with the source feature" do

--- a/spec/rollout/feature_state_spec.rb
+++ b/spec/rollout/feature_state_spec.rb
@@ -1,0 +1,143 @@
+require "spec_helper"
+
+RSpec.describe Rollout::FeatureState do
+  let(:rollout) { Rollout.new($redis) }
+
+  def build_state(overrides = {})
+    described_class.new(**{
+      name: :chat,
+      percentage: 25,
+      users: [123, "456"],
+      groups: [:employees, "supporters"],
+      data: { description: "New navigation", "updated_at" => 1 },
+    }.merge(overrides))
+  end
+
+  def feature_for(state, options: rollout.options)
+    Rollout::Feature.new(state: state, rollout: rollout, options: options)
+  end
+
+  it "normalizes persistence types" do
+    state = build_state
+
+    expect(state.name).to eq "chat"
+    expect(state.percentage).to eq 25.0
+    expect(state.users).to eq %w[123 456]
+    expect(state.groups).to eq %w[employees supporters]
+    expect(state.data).to eq("description" => "New navigation", "updated_at" => 1)
+  end
+
+  it "does not share collections with the caller" do
+    users = ["123"]
+    groups = ["employees"]
+    nested = ["a"]
+    data = { "labels" => nested }
+    state = build_state(users: users, groups: groups, data: data)
+
+    users << "456"
+    groups << "supporters"
+    nested << "b"
+    data["labels"] << "c"
+
+    expect(state.users).to eq %w[123]
+    expect(state.groups).to eq %w[employees]
+    expect(state.data).to eq("labels" => ["a"])
+  end
+
+  it "does not share nested data or strings with its clone" do
+    description = +"hello"
+    state = build_state(data: { "description" => description, "labels" => ["a"] })
+    clone = state.deep_clone
+
+    clone.users << "999"
+    clone.groups << "admins"
+    clone.data["labels"] << "b"
+    clone.data["description"] << "!"
+    description << "?"
+
+    expect(state.users).to eq %w[123 456]
+    expect(state.groups).to eq %w[employees supporters]
+    expect(state.data).to eq("description" => "hello", "labels" => ["a"])
+    expect(clone.data["description"]).to eq "hello!"
+  end
+
+  describe "Feature conversion" do
+    it "round-trips evaluation and metadata" do
+      rollout.define_group(:employees) { |user| user.id == 1 }
+      rollout.activate_percentage(:chat, 20)
+      rollout.activate_user(:chat, 42)
+      rollout.activate_group(:chat, :employees)
+      rollout.set_feature_data(:chat, description: "New navigation")
+
+      feature = rollout.get(:chat)
+      state = feature.to_feature_state
+      restored = feature_for(state)
+
+      expect(state.name).to eq "chat"
+      expect(state.percentage).to eq 20.0
+      expect(state.users).to eq %w[42]
+      expect(state.groups).to eq %w[employees]
+      expect(state.data).to eq("description" => "New navigation")
+      expect(restored.name).to eq "chat"
+
+      expect(restored.active?(double(id: 1))).to eq feature.active?(double(id: 1))
+      expect(restored.active?(double(id: 42))).to eq feature.active?(double(id: 42))
+      expect(restored.active?(double(id: 2))).to eq feature.active?(double(id: 2))
+      expect(restored.to_hash).to eq feature.to_hash
+    end
+
+    it "does not expose assign_state" do
+      feature = rollout.get(:chat)
+
+      expect(feature).not_to respond_to(:assign_state)
+      expect(feature.private_methods).to include(:assign_state)
+    end
+
+    it "does not share nested data with the source feature" do
+      rollout.set_feature_data(:chat, labels: ["a"])
+      feature = rollout.get(:chat)
+      state = feature.to_feature_state
+
+      feature.data["labels"] << "b"
+
+      expect(state.data).to eq("labels" => ["a"])
+    end
+
+    it "does not share nested data with a reconstructed feature" do
+      nested = ["a"]
+      state = build_state(data: { "labels" => nested })
+      feature = feature_for(state)
+
+      feature.data["labels"] << "b"
+      nested << "c"
+      state.data["labels"] << "d"
+
+      expect(feature.data).to eq("labels" => ["a", "b"])
+      expect(state.data).to eq("labels" => ["a", "d"])
+    end
+
+    it "uses sets when use_sets is enabled" do
+      feature = feature_for(build_state, options: { use_sets: true })
+
+      expect(feature.users).to eq %w[123 456].to_set
+      expect(feature.groups).to eq %i[employees supporters].to_set
+    end
+
+    it "preserves randomized percentage evaluation through a round trip" do
+      randomized = Rollout.new($redis, randomize_percentage: true)
+      randomized.activate_percentage(:chat, 20)
+
+      feature = randomized.get(:chat)
+      restored = Rollout::Feature.new(
+        state: feature.to_feature_state,
+        rollout: randomized,
+        options: randomized.options,
+      )
+
+      expect(restored.active?(double(id: 1))).to eq true
+      expect(restored.active?(double(id: 2))).to eq false
+      expect(restored.active?(double(id: 1))).to eq feature.active?(double(id: 1))
+      expect(restored.active?(double(id: 2))).to eq feature.active?(double(id: 2))
+    end
+  end
+end

--- a/spec/rollout/feature_state_spec.rb
+++ b/spec/rollout/feature_state_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Rollout::FeatureState do
       expect(state.users).to eq %w[42]
       expect(state.groups).to eq %w[employees]
       expect(state.data).to eq("description" => "New navigation")
-      expect(restored.name).to eq "chat"
+      expect(restored.name).to eq :chat
 
       expect(restored.active?(double(id: 1))).to eq feature.active?(double(id: 1))
       expect(restored.active?(double(id: 42))).to eq feature.active?(double(id: 42))

--- a/spec/rollout/logging_spec.rb
+++ b/spec/rollout/logging_spec.rb
@@ -139,5 +139,77 @@ RSpec.describe 'Rollout::Logging' do
       expect(event).to be_nil
     end
   end
+
+  context 'no-op mutations' do
+    it 'does not write a history event when nothing changes' do
+      rollout.activate_percentage(feature, 25)
+
+      expect do
+        rollout.activate_percentage(feature, 25)
+      end.not_to change { rollout.logging.events(feature).count }
+    end
+  end
+
+  context 'multi-field edits' do
+    it 'records one event for a with_feature block' do
+      rollout.logging.with_context(actor: 'alice') do
+        rollout.with_feature(feature) do |current|
+          current.percentage = 25.0
+          current.groups = [:employees]
+          current.users = ['123']
+          current.data.update(description: 'New navigation')
+        end
+      end
+
+      events = rollout.logging.events(feature)
+      expect(events.count).to eq 1
+      expect(events.first.context).to eq(actor: 'alice')
+      expect(events.first.data[:before].keys).to contain_exactly(:percentage, :groups, :users, :"data.description")
+      expect(events.first.data[:after]).to include(
+        percentage: 25.0,
+        groups: ['employees'],
+        users: ['123'],
+        "data.description": 'New navigation',
+      )
+    end
+  end
+
+  context 'delete versus clear' do
+    it 'removes feature history on delete' do
+      rollout.activate_percentage(feature, 25)
+      expect(rollout.logging.events(feature)).not_to be_empty
+
+      rollout.delete(feature)
+
+      expect(rollout.logging.events(feature)).to eq []
+    end
+
+    it 'keeps feature history on clear!' do
+      rollout.activate_percentage(feature, 25)
+
+      rollout.clear!
+
+      expect(rollout.features).to eq []
+      expect(rollout.logging.events(feature).map { |event| event.data[:after][:percentage] }).to eq [25, 0]
+    end
+  end
+
+  context 'persisted history keys' do
+    let(:logging) { { history_length: 2, global: true } }
+
+    it 'writes truncated per-feature and global sorted sets' do
+      rollout.activate_percentage(feature, 25)
+      rollout.activate_percentage(feature, 50)
+      rollout.activate_percentage(feature, 75)
+
+      feature_key = "feature:#{feature}:logging:events"
+      global_key = "feature:_global_:logging:events"
+
+      expect($redis.zcard(feature_key)).to eq 2
+      expect($redis.zcard(global_key)).to eq 2
+      expect(rollout.logging.events(feature).map { |event| event.data[:after][:percentage] }).to eq [50, 75]
+      expect(rollout.logging.global_events.map { |event| event.data[:after][:percentage] }).to eq [50, 75]
+    end
+  end
 end
 

--- a/spec/rollout/redis_codec_spec.rb
+++ b/spec/rollout/redis_codec_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+RSpec.describe Rollout::RedisCodec do
+  it "decodes a missing payload as an empty feature" do
+    state = described_class.decode(:chat, nil)
+
+    expect(state).to eq(
+      Rollout::FeatureState.new(
+        name: :chat,
+        percentage: 0,
+        users: [],
+        groups: [],
+        data: {},
+      ),
+    )
+  end
+
+  it "decodes an empty payload as an empty feature" do
+    state = described_class.decode(:chat, "")
+
+    expect(state.percentage).to eq 0.0
+    expect(state.users).to eq []
+    expect(state.groups).to eq []
+    expect(state.data).to eq({})
+  end
+
+  it "decodes a stored payload" do
+    state = described_class.decode(
+      :chat,
+      '10.5|7,8|greeters|{"description":"legacy"}',
+    )
+
+    expect(state.name).to eq "chat"
+    expect(state.percentage).to eq 10.5
+    expect(state.users).to eq %w[7 8]
+    expect(state.groups).to eq %w[greeters]
+    expect(state.data).to eq("description" => "legacy")
+  end
+
+  it "decodes payloads with no metadata" do
+    expect(described_class.decode(:chat, "0||").data).to eq({})
+    expect(described_class.decode(:chat, "|||   ").data).to eq({})
+  end
+
+  it "encodes feature state using the current redis format" do
+    state = Rollout::FeatureState.new(
+      name: :chat,
+      percentage: 20,
+      users: ["42"],
+      groups: ["employees"],
+      data: { "description" => "foo" },
+    )
+
+    expect(described_class.encode(state)).to eq('20.0|42|employees|{"description":"foo"}')
+  end
+
+  it "round-trips a payload" do
+    payload = '10.5|7,8|greeters|{"description":"legacy"}'
+    state = described_class.decode(:chat, payload)
+
+    expect(described_class.encode(state)).to eq payload
+  end
+end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -308,6 +308,30 @@ RSpec.describe "Rollout" do
     end
   end
 
+  describe "exact CRC32 percentage assignment" do
+    it "keeps the same users across features when randomize_percentage is off" do
+      rollout.activate_percentage(:chat, 20)
+      rollout.activate_percentage(:beta, 20)
+
+      expect(rollout.active?(:chat, double(id: 2))).to eq true
+      expect(rollout.active?(:chat, double(id: 6))).to eq true
+      expect(rollout.active?(:chat, double(id: 1))).to eq false
+      expect(rollout.active?(:beta, double(id: 2))).to eq true
+      expect(rollout.active?(:beta, double(id: 1))).to eq false
+    end
+
+    it "changes assignment by feature name when randomize_percentage is on" do
+      randomized = Rollout.new($redis, randomize_percentage: true)
+      randomized.activate_percentage(:chat, 20)
+      randomized.activate_percentage(:beta, 20)
+
+      expect(randomized.active?(:chat, double(id: 1))).to eq true
+      expect(randomized.active?(:beta, double(id: 1))).to eq false
+      expect(randomized.active?(:chat, double(id: 5))).to eq false
+      expect(randomized.active?(:beta, double(id: 5))).to eq true
+    end
+  end
+
   describe "activating a feature for a group as a string" do
     before do
       rollout.define_group(:admins) { |user| user.id == 5 }
@@ -512,24 +536,24 @@ RSpec.describe "Rollout" do
 
     context "with user argument" do
       it "maps active feature as true" do
-        state = rollout.feature_states(user_double)[:video]
+        state = rollout.feature_states(user_double)["video"]
         expect(state).to eq(true)
       end
 
       it "maps inactive feature as false" do
-        state = rollout.feature_states[:vr]
+        state = rollout.feature_states["vr"]
         expect(state).to eq(false)
       end
     end
 
     context "with no argument" do
       it "maps active feature as true" do
-        state = rollout.feature_states[:chat]
+        state = rollout.feature_states["chat"]
         expect(state).to eq(true)
       end
 
       it "maps inactive feature as false" do
-        state = rollout.feature_states[:video]
+        state = rollout.feature_states["video"]
         expect(state).to eq(false)
       end
     end
@@ -551,25 +575,25 @@ RSpec.describe "Rollout" do
     context "with user argument" do
       it "includes active feature" do
         features = rollout.active_features(user_double)
-        expect(features).to include(:video)
-        expect(features).to include(:chat)
+        expect(features).to include("video")
+        expect(features).to include("chat")
       end
 
       it "excludes inactive feature" do
         features = rollout.active_features(user_double)
-        expect(features).to_not include(:vr)
+        expect(features).to_not include("vr")
       end
     end
 
     context "with no argument" do
       it "includes active feature" do
         features = rollout.active_features
-        expect(features).to include(:chat)
+        expect(features).to include("chat")
       end
 
       it "excludes inactive feature" do
         features = rollout.active_features
-        expect(features).to_not include(:video)
+        expect(features).to_not include("video")
       end
     end
   end
@@ -597,12 +621,12 @@ RSpec.describe "Rollout" do
 
     it "returns an array of features" do
       features = rollout.multi_get(:chat, :videos, :signup)
-      expect(features[0].name).to eq :chat
+      expect(features[0].name).to eq "chat"
       expect(features[0].groups).to eq [:caretakers]
       expect(features[0].percentage).to eq 10
-      expect(features[1].name).to eq :videos
+      expect(features[1].name).to eq "videos"
       expect(features[1].groups).to eq [:greeters]
-      expect(features[2].name).to eq :signup
+      expect(features[2].name).to eq "signup"
       expect(features[2].percentage).to eq 100
       expect(features.size).to eq 3
     end
@@ -661,6 +685,102 @@ RSpec.describe "Rollout" do
       expect(rollout.get(:chat).data).to include('description' => 'foo')
       rollout.clear_feature_data(:chat)
       expect(rollout.get(:chat).data).to eq({})
+    end
+  end
+
+  describe "persisted redis format" do
+    it "writes the current feature payload and registry keys" do
+      rollout.activate_percentage(:chat, 20)
+      rollout.activate_user(:chat, 42)
+      rollout.activate_group(:chat, :employees)
+      rollout.set_feature_data(:chat, description: "foo")
+
+      expect($redis.get("feature:chat")).to eq('20.0|42|employees|{"description":"foo"}')
+      expect($redis.get("feature:__features__")).to eq("chat")
+    end
+
+    it "reads an existing payload without rewriting it" do
+      $redis.set("feature:chat", '10.5|7,8|greeters|{"description":"legacy"}')
+      $redis.set("feature:__features__", "chat")
+
+      feature = rollout.get(:chat)
+
+      expect(feature.percentage).to eq 10.5
+      expect(feature.users).to eq %w[7 8]
+      expect(feature.groups).to eq [:greeters]
+      expect(feature.data).to eq("description" => "legacy")
+      expect($redis.get("feature:chat")).to eq('10.5|7,8|greeters|{"description":"legacy"}')
+    end
+  end
+
+  describe "mutation semantics" do
+    it "saves multiple with_feature edits together" do
+      rollout.with_feature(:chat) do |feature|
+        feature.percentage = 25.0
+        feature.groups = [:employees]
+        feature.users = ["123"]
+        feature.data.update(description: "New navigation")
+      end
+
+      feature = rollout.get(:chat)
+      expect(feature.percentage).to eq 25.0
+      expect(feature.groups).to eq [:employees]
+      expect(feature.users).to eq %w[123]
+      expect(feature.data).to eq("description" => "New navigation")
+    end
+
+    it "does not save when the with_feature block raises" do
+      expect do
+        rollout.with_feature(:chat) do |feature|
+          feature.percentage = 100
+          raise "boom"
+        end
+      end.to raise_error("boom")
+
+      expect(rollout.get(:chat).percentage).to eq 0
+      expect(rollout.exists?(:chat)).to eq false
+    end
+
+    it "clears users, groups, percentage, and data on deactivate" do
+      rollout.activate_user(:chat, 42)
+      rollout.activate_group(:chat, :employees)
+      rollout.activate_percentage(:chat, 50)
+      rollout.set_feature_data(:chat, description: "foo")
+
+      rollout.deactivate(:chat)
+
+      expect(rollout.features).to eq [:chat]
+      expect(rollout.get(:chat).to_hash).to eq(
+        percentage: 0,
+        users: [],
+        groups: [],
+        data: {},
+      )
+      expect($redis.get("feature:chat")).to eq("0.0|||{}")
+    end
+
+    it "keeps users, groups, and data on deactivate_percentage" do
+      rollout.activate_user(:chat, 42)
+      rollout.activate_group(:chat, :employees)
+      rollout.activate_percentage(:chat, 50)
+      rollout.set_feature_data(:chat, description: "foo")
+
+      rollout.deactivate_percentage(:chat)
+
+      expect(rollout.get(:chat).percentage).to eq 0
+      expect(rollout.get(:chat).users).to eq %w[42]
+      expect(rollout.get(:chat).groups).to eq [:employees]
+      expect(rollout.get(:chat).data).to eq("description" => "foo")
+    end
+
+    it "removes the feature on delete and leaves a missing feature inactive" do
+      rollout.activate(:chat)
+      rollout.delete(:chat)
+
+      expect(rollout.features).to eq []
+      expect(rollout.exists?(:chat)).to eq false
+      expect(rollout.get(:chat).percentage).to eq 0
+      expect(rollout.active?(:chat)).to eq false
     end
   end
 

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -536,24 +536,24 @@ RSpec.describe "Rollout" do
 
     context "with user argument" do
       it "maps active feature as true" do
-        state = rollout.feature_states(user_double)["video"]
+        state = rollout.feature_states(user_double)[:video]
         expect(state).to eq(true)
       end
 
       it "maps inactive feature as false" do
-        state = rollout.feature_states["vr"]
+        state = rollout.feature_states[:vr]
         expect(state).to eq(false)
       end
     end
 
     context "with no argument" do
       it "maps active feature as true" do
-        state = rollout.feature_states["chat"]
+        state = rollout.feature_states[:chat]
         expect(state).to eq(true)
       end
 
       it "maps inactive feature as false" do
-        state = rollout.feature_states["video"]
+        state = rollout.feature_states[:video]
         expect(state).to eq(false)
       end
     end
@@ -575,25 +575,25 @@ RSpec.describe "Rollout" do
     context "with user argument" do
       it "includes active feature" do
         features = rollout.active_features(user_double)
-        expect(features).to include("video")
-        expect(features).to include("chat")
+        expect(features).to include(:video)
+        expect(features).to include(:chat)
       end
 
       it "excludes inactive feature" do
         features = rollout.active_features(user_double)
-        expect(features).to_not include("vr")
+        expect(features).to_not include(:vr)
       end
     end
 
     context "with no argument" do
       it "includes active feature" do
         features = rollout.active_features
-        expect(features).to include("chat")
+        expect(features).to include(:chat)
       end
 
       it "excludes inactive feature" do
         features = rollout.active_features
-        expect(features).to_not include("video")
+        expect(features).to_not include(:video)
       end
     end
   end
@@ -621,12 +621,12 @@ RSpec.describe "Rollout" do
 
     it "returns an array of features" do
       features = rollout.multi_get(:chat, :videos, :signup)
-      expect(features[0].name).to eq "chat"
+      expect(features[0].name).to eq :chat
       expect(features[0].groups).to eq [:caretakers]
       expect(features[0].percentage).to eq 10
-      expect(features[1].name).to eq "videos"
+      expect(features[1].name).to eq :videos
       expect(features[1].groups).to eq [:greeters]
-      expect(features[2].name).to eq "signup"
+      expect(features[2].name).to eq :signup
       expect(features[2].percentage).to eq 100
       expect(features.size).to eq 3
     end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -461,6 +461,11 @@ RSpec.describe "Rollout" do
       expect(feature.percentage).to eq(100)
     end
 
+    it "preserves the requested name type" do
+      expect(rollout.get("chat").name).to eq "chat"
+      expect(rollout.get(:chat).name).to eq :chat
+    end
+
     it "returns the feature objects using sets" do
       @options = rollout.instance_variable_get("@options")
       @options[:use_sets] = true
@@ -629,6 +634,10 @@ RSpec.describe "Rollout" do
       expect(features[2].name).to eq :signup
       expect(features[2].percentage).to eq 100
       expect(features.size).to eq 3
+    end
+
+    it "preserves the requested name types" do
+      expect(rollout.multi_get("chat", :videos).map(&:name)).to eq ["chat", :videos]
     end
 
     describe 'when given feature keys is empty' do


### PR DESCRIPTION
## Summary
- Introduce `Rollout::FeatureState` as the backend-neutral snapshot of feature configuration.
- Move Redis payload encode/decode into `Rollout::RedisCodec` and construct `Feature` only from `FeatureState`.
- Pin current CRC32 assignment, Redis payload format, mutation semantics, and history behavior with characterization tests.

This is the first Rollout 3 slice. It does not extract `rollout-redis`, add Active Record, change hashing, or raise the Ruby requirement.

## Test plan
- [ ] CI green on the existing Ruby 2.4–3.3 matrix
- [x] Existing Redis payloads still load without rewriting unread keys
- [x] Percentage, user, and group evaluation match the pinned CRC32 examples
- [x] `with_feature` still saves one combined mutation and records one history event
- [x] `delete` removes feature history; `clear!` keeps it