### PR TITLE
Release core and Redis adapter gems from package-prefixed tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,11 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,7 +20,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
       - name: Select package
         id: package
         run: |
@@ -47,31 +37,14 @@ jobs:
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "directory=$directory" >> "$GITHUB_OUTPUT"
-      - name: Run core tests
-        run: bundle exec rspec spec
-      - name: Setup Redis adapter gems
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-          working-directory: rollout-redis
-          bundler-cache: true
-      - name: Run Redis adapter tests
-        working-directory: rollout-redis
-        run: bundle exec rspec
       - name: Build selected gem
         working-directory: ${{ steps.package.outputs.directory }}
         run: gem build "${{ steps.package.outputs.name }}.gemspec"
-      - name: Publish rollout
-        if: steps.package.outputs.name == 'rollout'
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: gem push "rollout-${{ steps.package.outputs.version }}.gem"
-      - name: Publish rollout-redis
-        if: steps.package.outputs.name == 'rollout-redis'
-        working-directory: rollout-redis
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: gem push "rollout-redis-${{ steps.package.outputs.version }}.gem"
+      - name: Configure RubyGems credentials
+        uses: rubygems/configure-rubygems-credentials@v2.1.0
+      - name: Publish selected gem
+        working-directory: ${{ steps.package.outputs.directory }}
+        run: gem push "${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}.gem"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.package.outputs.name == 'rollout-redis'
         working-directory: rollout-redis
         env:
-          GEM_HOST_API_KEY: ${{ secrets.ROLLOUT_REDIS_RUBYGEMS_API_KEY }}
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: gem push "rollout-redis-${{ steps.package.outputs.version }}.gem"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'rollout/v*'
+      - 'rollout-redis/v*'
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -25,6 +29,23 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - name: Select package
+        id: package
+        run: |
+          case "$GITHUB_REF_NAME" in
+            rollout/v*) name=rollout; directory=. ;;
+            rollout-redis/v*) name=rollout-redis; directory=rollout-redis ;;
+            *) echo "Unexpected tag $GITHUB_REF_NAME" >&2; exit 1 ;;
+          esac
+          version="${GITHUB_REF_NAME##*/v}"
+          spec_version=$(ruby -e 'puts Gem::Specification.load(ARGV[0]).version' "$directory/$name.gemspec")
+          if [ "$spec_version" != "$version" ]; then
+            echo "Tag version $version does not match gemspec $spec_version" >&2
+            exit 1
+          fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "directory=$directory" >> "$GITHUB_OUTPUT"
       - name: Run core tests
         run: bundle exec rspec spec
       - name: Setup Redis adapter gems
@@ -35,20 +56,25 @@ jobs:
       - name: Run Redis adapter tests
         working-directory: rollout-redis
         run: bundle exec rspec
+      - name: Build selected gem
+        working-directory: ${{ steps.package.outputs.directory }}
+        run: gem build "${{ steps.package.outputs.name }}.gemspec"
+      - name: Publish rollout
+        if: steps.package.outputs.name == 'rollout'
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push "rollout-${{ steps.package.outputs.version }}.gem"
+      - name: Publish rollout-redis
+        if: steps.package.outputs.name == 'rollout-redis'
+        working-directory: rollout-redis
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.ROLLOUT_REDIS_RUBYGEMS_API_KEY }}
+        run: gem push "rollout-redis-${{ steps.package.outputs.version }}.gem"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
-          name: ${{ github.ref_name }}
+          name: ${{ steps.package.outputs.name }} ${{ steps.package.outputs.version }}
           generate_release_notes: true
           draft: false
-          prerelease: false 
-      - name: Set up RubyGems credentials
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: |
-          mkdir -p ~/.gem
-          echo ":rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-      - name: Release to RubyGems
-        run: bundle exec rake release
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -34,9 +36,12 @@ jobs:
             echo "Tag version $version does not match gemspec $spec_version" >&2
             exit 1
           fi
+          previous_tag=$(git tag --list "$name/v*" --sort=-version:refname | awk -v current="$GITHUB_REF_NAME" '$0 != current { print; exit }')
+          previous_tag=${previous_tag:-v2.6.2}
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "directory=$directory" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
       - name: Build selected gem
         working-directory: ${{ steps.package.outputs.directory }}
         run: gem build "${{ steps.package.outputs.name }}.gemspec"
@@ -51,5 +56,6 @@ jobs:
           tag_name: ${{ github.ref }}
           name: ${{ steps.package.outputs.name }} ${{ steps.package.outputs.version }}
           generate_release_notes: true
+          previous_tag: ${{ steps.package.outputs.previous_tag }}
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Select package
         id: package
@@ -51,6 +52,7 @@ jobs:
       - name: Setup Redis adapter gems
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '3.3'
           working-directory: rollout-redis
           bundler-cache: true
       - name: Run Redis adapter tests

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Optional connection settings: `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`.
 
 - Update and commit the version in `lib/rollout/version.rb` or `rollout-redis/rollout-redis.gemspec`.
 - Tag the release commit with `rollout/vX.Y.Z` or `rollout-redis/vX.Y.Z`, matching the gem version.
-- Push the tag with `git push origin <tag>`. CI tests both gems, publishes the selected gem, and creates its GitHub release.
+- Push the tag with `git push origin <tag>`. CI publishes the selected gem and creates its GitHub release.
 
 Use package-prefixed tags, not `vX.Y.Z`.
 

--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ Optional connection settings: `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`.
 
 ## Releasing
 
-1. Bump version: `rake version:patch` (or `minor`/`major`)
-2. Commit and tag: `git commit -am "Bump version" && git tag v0.7.3`
-3. Push: `git push origin master --tags`
+- Update and commit the version in `lib/rollout/version.rb` or `rollout-redis/rollout-redis.gemspec`.
+- Tag the release commit with `rollout/vX.Y.Z` or `rollout-redis/vX.Y.Z`, matching the gem version.
+- Push the tag with `git push origin <tag>`. CI tests both gems, publishes the selected gem, and creates its GitHub release.
 
-The GitHub Actions workflow will automatically publish to RubyGems when tags are pushed.
+Use package-prefixed tags, not `vX.Y.Z`.
 
 ## Copyright
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec) do |task|


### PR DESCRIPTION
## Summary
- Release `rollout` from `rollout/vX.Y.Z` and `rollout-redis` from `rollout-redis/vX.Y.Z`.
- Authenticate with RubyGems Trusted Publishing instead of a stored API key.
- Publish only the tagged gem and create its GitHub release. Tests stay in the Test workflow.

## Release
1. Update and commit the gem version.
2. Tag the commit (`rollout/v3.0.0` or `rollout-redis/v0.1.0`).
3. `git push origin <tag>`.

Register the same `release.yml` workflow as a trusted publisher for both gems. If that publisher specifies a GitHub environment, add the same `environment:` to this job.