### PR TITLE
Allow redis gem 6 in rollout-redis

### DIFF
--- a/rollout-redis/rollout-redis.gemspec
+++ b/rollout-redis/rollout-redis.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'redis', '>= 4.0', '< 6'
+  spec.add_dependency 'redis', '>= 4.0', '< 7'
   spec.add_dependency 'rollout', '>= 3.0', '< 4'
 end


### PR DESCRIPTION
## Summary
- Widen `rollout-redis` to `redis >= 4.0, < 7` so Redis gem 6.0.0 can be used.
- Adapter commands we use keep compatible return values under redis-rb 6 (RESP3 by default; GEO is the only documented return-value change).
- Redis gem 6 requires Ruby 3.2+; older Rubies can still resolve 4.x/5.x.

Related to https://github.com/fetlife/rollout/issues/179

## Test plan
- [x] Adapter specs pass against redis gem 6.0.0
- [x] CI redis job on this PR